### PR TITLE
[FEAT/#24] 공용 divider 구현  완료

### DIFF
--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { shadows } from "@/shared/styles/shadows";
 import { SmallButton } from "@/shared/ui/buttons/ActionButton";
 import { BenefitSelectionGroup } from "@/shared/ui/buttons/BenefitSelectionGroup";
 import { MediumButton } from "@/shared/ui/buttons/SubmitButton";
+import { Divider } from "@/shared/ui/divider";
 
 export default function HomeScreen() {
 	return (
@@ -210,6 +211,11 @@ export default function HomeScreen() {
 			{/* MediumButton 예시 */}
 			<View className="items-center mb-12">
 				<MediumButton onPress={() => {}}>인증완료</MediumButton>
+			</View>
+
+			{/* Divider 예시 */}
+			<View className="mb-12">
+				<Divider />
 			</View>
 		</ScrollView>
 	);

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { shadows } from "@/shared/styles/shadows";
 import { SmallButton } from "@/shared/ui/buttons/ActionButton";
 import { BenefitSelectionGroup } from "@/shared/ui/buttons/BenefitSelectionGroup";
 import { MediumButton } from "@/shared/ui/buttons/SubmitButton";
-import { Divider } from "@/shared/ui/divider";
+import { DividerDemo } from "@/shared/ui/divider";
 
 export default function HomeScreen() {
 	return (
@@ -214,9 +214,7 @@ export default function HomeScreen() {
 			</View>
 
 			{/* Divider 예시 */}
-			<View className="mb-12">
-				<Divider />
-			</View>
+			<DividerDemo />
 		</ScrollView>
 	);
 }

--- a/src/entities/chat/index.ts
+++ b/src/entities/chat/index.ts
@@ -1,2 +1,6 @@
-export type { ChatRoomItemProps, Message, MessageItemProps } from "./model/types";
+export type {
+	ChatRoomItemProps,
+	Message,
+	MessageItemProps,
+} from "./model/types";
 export { ChatRoomItem, MessageBubble, MessageItem, MessageTime } from "./ui";

--- a/src/entities/chat/ui/ChatRoomItem.tsx
+++ b/src/entities/chat/ui/ChatRoomItem.tsx
@@ -18,9 +18,7 @@ export function ChatRoomItem({
 
 				{/* Text area */}
 				<View className="shrink">
-					<Text
-className="font-bold text-[16px] leading-[22px] text-content-primary"
-					>
+					<Text className="font-bold text-[16px] leading-[22px] text-content-primary">
 						{roomName}
 					</Text>
 					<Text

--- a/src/entities/chat/ui/MessageItem.tsx
+++ b/src/entities/chat/ui/MessageItem.tsx
@@ -6,7 +6,11 @@ import type { MessageItemProps } from "../model/types";
 import { MessageBubble } from "./MessageBubble";
 import { MessageTime } from "./MessageTime";
 
-export function MessageItem({ message, isMine, profileImage }: MessageItemProps) {
+export function MessageItem({
+	message,
+	isMine,
+	profileImage,
+}: MessageItemProps) {
 	const variant = isMine ? "sent" : "received";
 
 	if (isMine) {

--- a/src/features/send-message/ui/ChatBar.tsx
+++ b/src/features/send-message/ui/ChatBar.tsx
@@ -9,10 +9,7 @@ interface ChatBarProps {
 	onAttach?: () => void;
 }
 
-export function ChatBar({
-	onSend,
-	onAttach,
-}: ChatBarProps) {
+export function ChatBar({ onSend, onAttach }: ChatBarProps) {
 	const [text, setText] = useState("");
 
 	const canSend = text.trim().length > 0;

--- a/src/shared/ui/comment/comment.md
+++ b/src/shared/ui/comment/comment.md
@@ -1,0 +1,42 @@
+# Comment Component
+
+댓글 UI 컴포넌트 모음입니다. `CommentCard`를 통해 전체 댓글을 렌더링할 수 있습니다.
+
+### 가장 중요한 점: index.tsx에서
+
+## 사용 방법
+
+### 기본 사용법
+
+```typescript
+import { CommentCard } from "@/shared/ui/comment";
+
+function MyComponent() {
+  return (
+    <CommentCard
+      comment={{
+        author: { department: "컴퓨터학부" },
+        rating: 5,
+        content: "정말 좋은 강의입니다!",
+        createdAt: new Date("2025-03-15"),
+      }}
+      onDelete={() => console.log("삭제")}
+    />
+  );
+}
+```
+
+## Props
+
+| Props      | 타입     | 필수 | 설명                                                  |
+| ---------- | -------- | ---- | ----------------------------------------------------- |
+| `comment`  | object   | ✅   | `author`, `rating`, `content`, `createdAt`, `images?` |
+| `onDelete` | function | ✅   | 삭제 클릭 시 실행 함수                                |
+
+**comment 객체:**
+
+- `author.department` (string) - 학과/직책
+- `rating` (number) - 평점 1~5
+- `content` (string) - 댓글 텍스트
+- `createdAt` (Date) - 작성 시간
+- `images?` (string[]) - 선택사항, 이미지 URL 배열

--- a/src/shared/ui/divider/Divider.tsx
+++ b/src/shared/ui/divider/Divider.tsx
@@ -1,0 +1,5 @@
+import { View } from "react-native";
+
+export function Divider() {
+	return <View className="w-full h-1 bg-neutral rounded-sm px-1.5" />;
+}

--- a/src/shared/ui/divider/DividerDemo.tsx
+++ b/src/shared/ui/divider/DividerDemo.tsx
@@ -1,0 +1,10 @@
+import { View } from "react-native";
+import { Divider } from "./Divider";
+
+export function DividerDemo() {
+	return (
+		<View className="mb-12">
+			<Divider />
+		</View>
+	);
+}

--- a/src/shared/ui/divider/index.ts
+++ b/src/shared/ui/divider/index.ts
@@ -1,0 +1,1 @@
+export { Divider } from "./Divider";

--- a/src/shared/ui/divider/index.ts
+++ b/src/shared/ui/divider/index.ts
@@ -1,1 +1,2 @@
 export { Divider } from "./Divider";
+export { DividerDemo } from "./DividerDemo";

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,2 +1,3 @@
+export * from "./divider";
 export * from "./profile";
 export * from "./select";

--- a/src/shared/ui/profile/ProfileAvatar.tsx
+++ b/src/shared/ui/profile/ProfileAvatar.tsx
@@ -1,5 +1,5 @@
-import { Image } from "expo-image";
 import type { ImageSource } from "expo-image";
+import { Image } from "expo-image";
 import { View } from "react-native";
 
 const DEFAULT_PROFILE = require("@/shared/assets/images/default-profile.png");


### PR DESCRIPTION
## 📝 요약 
-  공통 컴포넌트 divider을 구현했습니다.

## ⚙️ 작업 내용 
- `src/shared/ui/divider/` 폴더 생성
- `Divider.tsx` 컴포넌트 구현 
- `src/shared/ui/index.ts`에 divider export 추가
- 메인 페이지 `src/app/(tabs)/index.tsx`에 Divider 컴포넌트 추가

## 🔗 관련 이슈 
- Closes #24 

## ✅ 체크리스트 
- [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
- [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
- [x] 변경 사항에 대한 테스트를 마쳤습니다.
- [x] 불필요한 로그(console.log)를 제거하였습니다.

## 💬 리뷰어에게 
<img width="1440" height="2828" alt="image" src="https://github.com/user-attachments/assets/f52e4234-410c-4675-bb76-2b62296db019" />