### PR TITLE
[FEAT/#59] 관리자 제휴건의함 페이지 구현

### DIFF
--- a/src/app/(protected)/(admin)/partner-ship-suggestion-box.tsx
+++ b/src/app/(protected)/(admin)/partner-ship-suggestion-box.tsx
@@ -1,0 +1,5 @@
+// 관리자 제휴 건의함 Stack 스크린 — AdminSuggestionBoxPage 마운트
+
+import { AdminSuggestionBoxPage } from "@/pages/admin/partner-ship-suggestion-box/ui/AdminSuggestionBoxPage";
+
+export default AdminSuggestionBoxPage;

--- a/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
+++ b/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
@@ -1,4 +1,6 @@
 // 관리자 대시보드 페이지 — 제휴 사용자 현황 전체 레이아웃
+
+import { router } from "expo-router";
 import { useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
@@ -47,7 +49,7 @@ export function AdminDashboardPage() {
 				activeOpacity={0.8}
 				className="bg-primary items-center justify-center rounded-[8px] h-[41px]"
 				onPress={() => {
-					// TODO: 제휴건의함 라우트 연결
+					router.push("/(protected)/(admin)/partner-ship-suggestion-box");
 				}}
 			>
 				<Text className="text-[11px] font-semibold text-content-inverse leading-caption tracking-caption">

--- a/src/pages/admin/dashboard/ui/UsageSection.tsx
+++ b/src/pages/admin/dashboard/ui/UsageSection.tsx
@@ -1,4 +1,4 @@
-// 제휴 이용현황 섹션 — 섹션 타이틀 + 바 차트 + 인사이트 카드
+// 제휴 이용현황 섹션: 섹션 타이틀 + 바 차트 + 인사이트 카드
 
 import type { ReactNode } from "react";
 import { Text, View } from "react-native";

--- a/src/pages/admin/partner-ship-suggestion-box/model/mockSuggestions.ts
+++ b/src/pages/admin/partner-ship-suggestion-box/model/mockSuggestions.ts
@@ -1,0 +1,51 @@
+// 제휴 건의함 목업 데이터 — API 연동 전 테스트용 더미 건의 목록
+
+import type { Suggestion } from "./types";
+
+export const mockSuggestions: Suggestion[] = [
+	{
+		id: "1",
+		storeName: "인쌩맥주",
+		department: "글로벌미디어학부",
+		studentStatus: "재학생",
+		content:
+			"제휴 이벤트 잘 이용하고 있어요!!! 취향이나 인쌩맥주 제휴 희망합니다 👍🏻",
+		createdAt: new Date("2025-03-15T18:36:00"),
+	},
+	{
+		id: "2",
+		storeName: "역전할머니맥주",
+		department: "컴퓨터학부",
+		studentStatus: "재학생",
+		content: "역전할머니 맥주 파인애플 샤베트 먹구싶어용",
+		createdAt: new Date("2025-03-15T18:36:00"),
+	},
+	{
+		id: "3",
+		storeName: "상도로3가",
+		department: "언론홍보학과",
+		studentStatus: "휴학생",
+		content:
+			"상도로3가 너무 비싸요. 할인 제휴 있으면 맨날 갈 거 같아요!!!! 10프로 할인정도 가능할까요 하하",
+		createdAt: new Date("2025-03-15T18:36:00"),
+	},
+	{
+		id: "4",
+		storeName: "스타벅스 숭실대점",
+		department: "경영학부",
+		studentStatus: "재학생",
+		content: "학교 근처 스타벅스 제휴해주시면 자주 이용할 것 같아요!",
+		createdAt: new Date("2025-03-14T10:20:00"),
+	},
+	{
+		id: "5",
+		storeName: "올리브영",
+		department: "사회복지학부",
+		studentStatus: "졸업생",
+		content:
+			"올리브영 할인 제휴 생기면 정말 좋겠어요. 많은 학생들이 이용할 듯해요.",
+		createdAt: new Date("2025-03-13T15:05:00"),
+	},
+];
+
+export const mockEmptySuggestions: Suggestion[] = [];

--- a/src/pages/admin/partner-ship-suggestion-box/model/types.ts
+++ b/src/pages/admin/partner-ship-suggestion-box/model/types.ts
@@ -1,0 +1,10 @@
+// 제휴 건의함 도메인 타입 — Suggestion 데이터 구조 정의
+
+export type Suggestion = {
+	id: string;
+	storeName: string;
+	department: string;
+	studentStatus: string;
+	content: string;
+	createdAt: Date;
+};

--- a/src/pages/admin/partner-ship-suggestion-box/ui/AdminSuggestionBoxPage.tsx
+++ b/src/pages/admin/partner-ship-suggestion-box/ui/AdminSuggestionBoxPage.tsx
@@ -1,0 +1,88 @@
+// 관리자 제휴 건의함 페이지 — 건의 건수 + 건의 카드 목록
+
+import { router } from "expo-router";
+import { useState } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
+import { BackArrowIcon } from "@/shared/assets/icons";
+import { colorTokens } from "@/shared/styles/tokens";
+import { InfoBanner } from "@/shared/ui/info/InfoBanner";
+import { PageLayout } from "@/shared/ui/layout/PageLayout";
+import {
+	mockEmptySuggestions,
+	mockSuggestions,
+} from "../model/mockSuggestions";
+import { SuggestionBoxEmptyState } from "./SuggestionBoxEmptyState";
+import { SuggestionCard } from "./SuggestionCard";
+
+const INFO_MESSAGE = "제휴 혜택을 받을 숭실대 학생들이 제휴 건의함이에요";
+
+const listContentStyle = {
+	gap: 20, // card-gap (20px) — 카드 간 간격
+	paddingHorizontal: 24, // screen-m (24px)
+	paddingTop: 24, // screen-m (24px) — n건 있어요 ↔ 첫 카드
+	paddingBottom: 20,
+} as const;
+
+export function AdminSuggestionBoxPage() {
+	// DEV ONLY
+	const [isEmpty, setIsEmpty] = useState(false);
+	const suggestions = isEmpty ? mockEmptySuggestions : mockSuggestions;
+	const count = suggestions.length;
+
+	return (
+		<PageLayout
+			className="flex-1 bg-canvas"
+			contentContainerClassName="flex-1"
+			withBottomInset
+		>
+			<View className="flex-row items-center px-gutter py-[16px]">
+				<Pressable onPress={() => router.back()} hitSlop={8}>
+					<BackArrowIcon
+						width={24}
+						height={24}
+						color={colorTokens.contentPrimary}
+					/>
+				</Pressable>
+				<View className="flex-1 items-center">
+					<Text className="text-[20px] font-semibold text-content-primary leading-caption tracking-caption">
+						제휴건의함
+					</Text>
+				</View>
+				<Pressable
+					onPress={() => setIsEmpty((v) => !v)}
+					className="bg-neutral-variant rounded-sm px-[6px] py-[2px]"
+				>
+					<Text className="text-[10px] font-medium text-content-secondary">
+						{isEmpty ? "돌아가기" : "빈화면"}
+					</Text>
+				</Pressable>
+			</View>
+
+			<View className="px-screen-m gap-screen-m mt-screen-m">
+				<InfoBanner message={INFO_MESSAGE} />
+				<Text className="text-sm font-medium text-content-primary leading-caption tracking-caption">
+					작성된 제휴건의가 <Text className="text-primary">{count}</Text>건
+					있어요
+				</Text>
+			</View>
+
+			{count === 0 ? (
+				<SuggestionBoxEmptyState />
+			) : (
+				<FlatList
+					data={suggestions}
+					keyExtractor={(item) => item.id}
+					renderItem={({ item }) => (
+						<SuggestionCard
+							{...item}
+							onReport={() => {
+								// TODO: 신고 처리
+							}}
+						/>
+					)}
+					contentContainerStyle={listContentStyle}
+				/>
+			)}
+		</PageLayout>
+	);
+}

--- a/src/pages/admin/partner-ship-suggestion-box/ui/SuggestionBoxEmptyState.tsx
+++ b/src/pages/admin/partner-ship-suggestion-box/ui/SuggestionBoxEmptyState.tsx
@@ -1,0 +1,16 @@
+// 제휴 건의함 빈 상태 — 건의가 없을 때 표시되는 안내 문구
+
+import { Text, View } from "react-native";
+
+export function SuggestionBoxEmptyState() {
+	return (
+		<View className="flex-1 items-center justify-center gap-[6px]">
+			<Text className="text-md font-medium text-content-primary leading-body text-center">
+				아직 제휴건의가 없어요
+			</Text>
+			<Text className="text-[14px] font-regular text-content-secondary leading-caption text-center">
+				{"제휴건의가 들어오면 여기서\n내역을 확인할 수 있어요!"}
+			</Text>
+		</View>
+	);
+}

--- a/src/pages/admin/partner-ship-suggestion-box/ui/SuggestionCard.tsx
+++ b/src/pages/admin/partner-ship-suggestion-box/ui/SuggestionCard.tsx
@@ -1,0 +1,53 @@
+// 제휴 건의 카드 — 가게명, 작성자(학과·재학상태), 건의 내용, 작성일을 표시하는 카드
+
+import { format } from "date-fns";
+import { Pressable, Text, View } from "react-native";
+import type { Suggestion } from "../model/types";
+
+interface SuggestionCardProps extends Suggestion {
+	onReport: () => void;
+}
+
+export function SuggestionCard({
+	storeName,
+	department,
+	studentStatus,
+	content,
+	createdAt,
+	onReport,
+}: SuggestionCardProps) {
+	return (
+		<View className="bg-neutral rounded-sm p-card-p">
+			<View className="flex-row items-center justify-between">
+				<Text className="text-lg font-medium text-content-primary leading-body tracking-body">
+					{storeName}
+				</Text>
+				<Pressable onPress={onReport} hitSlop={8}>
+					<Text className="text-sm font-regular text-content-secondary leading-caption tracking-caption">
+						신고하기
+					</Text>
+				</Pressable>
+			</View>
+
+			<View className="flex-row items-center gap-[8px] mt-gutter">
+				<Text className="text-sm font-regular text-content-primary leading-caption tracking-caption">
+					{department}
+				</Text>
+				<View className="bg-neutral-variant rounded-[999px] px-gutter">
+					<Text className="text-[11px] font-regular text-content-primary leading-caption tracking-caption">
+						{studentStatus}
+					</Text>
+				</View>
+			</View>
+
+			<View className="gap-[8px] mt-[8px]">
+				<Text className="text-sm font-regular text-content-primary leading-caption tracking-caption">
+					{content}
+				</Text>
+				<Text className="text-sm font-regular text-primary leading-caption tracking-caption">
+					{`작성일 | ${format(createdAt, "yyyy-MM-dd")}  ${format(createdAt, "HH:mm")}`}
+				</Text>
+			</View>
+		</View>
+	);
+}


### PR DESCRIPTION
## 📝 요약 
- 관리자 제휴 건의함 확인 페이지 UI 구현

## ⚙️ 작업 내용 
  - `SuggestionCard` 컴포넌트 구현 (가게명, 학과·재학상태, 건의 내용, 작성일, 신고하기)                                        
  - `SuggestionBoxEmptyState` 컴포넌트 구현 (건의가 없을 때 빈 화면)                                                           
  - `AdminDashboardPage`에서 제휴건의함 라우트 연결 
 
## 🔗 관련 이슈 
- Closes #59 

## ✅ 체크리스트 
- [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
- [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
- [x] 변경 사항에 대한 테스트를 마쳤습니다.
- [x] 불필요한 로그(console.log)를 제거하였습니다.

## 💬 리뷰어에게 
- 제휴건의함 페이지 우측 상단에 개발용 화면 전환 버튼을 넣어뒀습니다. (빈화면 ↔ 목데이터 전환) API 연동 시 제거 예정입니다.  

<img width="1440" height="2828" alt="image" src="https://github.com/user-attachments/assets/209e3260-a2bd-4936-9b04-24d38e121365" />
<img width="1440" height="2828" alt="image" src="https://github.com/user-attachments/assets/450fb68a-cd8f-497d-b08f-836514352a78" />
