### PR TITLE
[FIX/#69] 학생 제휴 건의함 페이지 텍스트 렌더링 버그 수정

### DIFF
--- a/src/pages/student/suggestion/ui/BenefitSummary.tsx
+++ b/src/pages/student/suggestion/ui/BenefitSummary.tsx
@@ -8,23 +8,23 @@ interface BenefitSummaryProps {
 
 export function BenefitSummary({ month, count }: BenefitSummaryProps) {
 	return (
-		<View className="gap-[13px]">
+		<View className="gap-gutter">
 			<View className="flex-row items-start gap-1">
-				<Text className="font-semibold text-[25px] text-primary leading-caption tracking-caption">
+				<Text className="font-semibold text-[25px] text-primary leading-heading tracking-caption">
 					{month}
 				</Text>
-				<Text className="font-semibold text-[25px] text-primary leading-caption tracking-caption">
+				<Text className="font-semibold text-[25px] text-primary leading-heading tracking-caption">
 					월의 혜택
 				</Text>
 			</View>
 			<View className="flex-row items-start gap-1">
-				<Text className="font-semibold text-[25px] text-content-primary leading-caption tracking-caption">
+				<Text className="font-semibold text-[25px] text-content-primary leading-heading tracking-caption">
 					서비스
 				</Text>
-				<Text className="font-semibold text-[25px] text-primary leading-caption tracking-caption">
+				<Text className="font-semibold text-[25px] text-primary leading-heading tracking-caption">
 					{count}
 				</Text>
-				<Text className="font-semibold text-[25px] text-content-primary leading-caption tracking-caption">
+				<Text className="font-semibold text-[25px] text-content-primary leading-heading tracking-caption">
 					건을 받았어요!
 				</Text>
 			</View>

--- a/src/pages/student/suggestion/ui/SuggestionSection.tsx
+++ b/src/pages/student/suggestion/ui/SuggestionSection.tsx
@@ -15,7 +15,7 @@ export function SuggestionSection() {
 			</View>
 			<View className="mx-screen-m bg-canvas px-gutter py-[18px] gap-card-p">
 				<View className="gap-card-p">
-					<Text className="font-semibold text-[25px] text-content-primary leading-caption tracking-caption">
+					<Text className="font-semibold text-[25px] text-content-primary leading-heading tracking-caption">
 						제휴 건의함
 					</Text>
 					<View>

--- a/src/shared/styles/global.styles.css
+++ b/src/shared/styles/global.styles.css
@@ -61,12 +61,14 @@
 	--size-letter-025: 0.25px;
 	--size-line-21: 21px;
 	--size-letter-minus-032: -0.32px;
+	--size-line-28: 28px;
 
 	/* Typography - Semantic */
 	--typography-body-line-height: var(--size-line-20);
 	--typography-body-letter-spacing: var(--size-letter-025);
 	--typography-caption-line-height: var(--size-line-21);
 	--typography-caption-letter-spacing: var(--size-letter-minus-032);
+	--typography-heading-line-height: var(--size-line-28);
 
 	/* Layout Spacing */
 	--layout-margin: 24px; /* 화면 좌우 전체 여백 */
@@ -149,12 +151,14 @@
 	--size-letter-025: 0.25px;
 	--size-line-21: 21px;
 	--size-letter-minus-032: -0.32px;
+	--size-line-28: 28px;
 
 	/* Typography - Semantic */
 	--typography-body-line-height: var(--size-line-20);
 	--typography-body-letter-spacing: var(--size-letter-025);
 	--typography-caption-line-height: var(--size-line-21);
 	--typography-caption-letter-spacing: var(--size-letter-minus-032);
+	--typography-heading-line-height: var(--size-line-28);
 
 	/* Layout Spacing */
 	--layout-margin: 24px; /* 화면 좌우 전체 여백 */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,7 @@ module.exports = {
 			lineHeight: {
 				body: "var(--typography-body-line-height)",
 				caption: "var(--typography-caption-line-height)",
+				heading: "var(--typography-heading-line-height)",
 			},
 			// 글자 간격
 			letterSpacing: {


### PR DESCRIPTION
## 📝 요약
  - iOS에서 헤딩 텍스트가 잘리는 버그 수정

  ## ⚙️ 작업 내용
  - `BenefitSummary.tsx` line-height를 `caption(21px)` → `heading(28px)`으로 교체
  - `--typography-heading-line-height` 디자인 토큰 추가 (global.styles.css, tailwind.config.js)

  ## 🔗 관련 이슈
  - Closes #69

  ## ✅ 체크리스트
  - [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
  - [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
  - [x] 변경 사항에 대한 테스트를 마쳤습니다.
  - [x] 불필요한 로그(console.log)를 제거하였습니다.

  ## 💬 리뷰어에게
  - font-size(25px)보다 작은 line-height(21px)가 적용되어 ios에서 글자가 클리핑되던 문제였습니다. 
  - heading용 line-height 토큰을 새로 추가하여 해결했습니다.