### PR TITLE
[FEAT/#82] 제휴업체 신고 관련 도메인 구현 및 리뷰 정렬 바텀시트 구현

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  jobs:
+    - name: biome-fix
+      glob: "src/**/*.{ts,tsx}"
+      run: yarn biome:fix {staged_files}
+      stage_fixed: true
+    - name: typecheck
+      run: yarn typecheck

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"concurrently": "^9.2.1",
 		"eslint": "^9.25.0",
 		"eslint-config-expo": "~10.0.0",
+		"lefthook": "^2.1.5",
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"react-native-svg-transformer": "^1.5.3",
 		"tailwindcss": "3.4.17",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.14",
+		"@expo/ngrok": "4.1.0",
 		"@types/react": "~19.1.10",
 		"babel-plugin-module-resolver": "^5.0.2",
 		"concurrently": "^9.2.1",

--- a/src/features/report-review/index.ts
+++ b/src/features/report-review/index.ts
@@ -1,0 +1,2 @@
+export { useReportReview } from "./model/useReportReview";
+export { ReportReviewDialog } from "./ui/ReportReviewDialog";

--- a/src/features/report-review/model/constants.ts
+++ b/src/features/report-review/model/constants.ts
@@ -1,0 +1,23 @@
+import type { ReportTarget } from "@/shared/ui/report";
+
+export const REVIEW_REPORT_REASONS: Record<
+	NonNullable<ReportTarget>,
+	readonly { value: string; label: string }[]
+> = {
+	user: [
+		{
+			value: "inappropriate",
+			label: "부적절한 내용 및 욕설이 포함한 글을 작성했어요",
+		},
+		{ value: "false", label: "허위사실 / 거짓이 포함된 글을 작성했어요" },
+		{ value: "ad", label: "홍보/광고를 위한 건의글을 작성했어요" },
+	],
+	post: [
+		{
+			value: "inappropriate",
+			label: "부적절한 내용 및 욕설이 포함된 리뷰에요",
+		},
+		{ value: "false", label: "허위사실 / 거짓이 포함된 리뷰에요" },
+		{ value: "ad", label: "홍보/광고를 위한 리뷰에요" },
+	],
+};

--- a/src/features/report-review/model/constants.ts
+++ b/src/features/report-review/model/constants.ts
@@ -7,17 +7,39 @@ export const REVIEW_REPORT_REASONS: Record<
 	user: [
 		{
 			value: "inappropriate",
-			label: "부적절한 내용 및 욕설이 포함한 글을 작성했어요",
+			label: "부적절한 내용 및 욕설이 포함된 글을 작성했어요",
 		},
 		{ value: "false", label: "허위사실 / 거짓이 포함된 글을 작성했어요" },
-		{ value: "ad", label: "홍보/광고를 위한 건의글을 작성했어요" },
+		{ value: "ad", label: "홍보/광고를 위한 글을 작성했어요" },
 	],
 	post: [
 		{
 			value: "inappropriate",
-			label: "부적절한 내용 및 욕설이 포함된 리뷰에요",
+			label: "부적절한 내용 및 욕설이 포함된 리뷰예요",
 		},
-		{ value: "false", label: "허위사실 / 거짓이 포함된 리뷰에요" },
-		{ value: "ad", label: "홍보/광고를 위한 리뷰에요" },
+		{ value: "false", label: "허위사실 / 거짓이 포함된 리뷰예요" },
+		{ value: "ad", label: "홍보/광고를 위한 리뷰예요" },
 	],
 };
+
+export const REVIEW_REPORT_CONFIG = {
+	targets: [
+		{ value: "user", label: "고객 리뷰 작성자" },
+		{ value: "post", label: "고객 리뷰 글" },
+	],
+	targetWarning:
+		"작성자를 신고할 경우 해당 사용자가 작성한 모든 리뷰가 비공개 처리됩니다",
+	reasons: (target: ReportTarget) => REVIEW_REPORT_REASONS[target ?? "post"],
+	reasonTitle: (target: ReportTarget) =>
+		target === "user"
+			? "작성자를 신고하는 사유를 선택해주세요"
+			: "고객 리뷰를 신고하는 사유를 선택해주세요",
+	doneTitle: (target: ReportTarget) =>
+		target === "user"
+			? "리뷰 작성자에 대한 신고가 완료되었습니다!"
+			: "리뷰의 신고가 완료되었습니다!",
+	doneBody: (target: ReportTarget) =>
+		target === "user"
+			? "신고 직후 해당 사용자가 작성한 모든 리뷰는 비공개 처리되며, 해당 사실이 작성자에게 고지되지 않습니다."
+			: "신고 직후 해당 리뷰는 비공개 처리되며, 부적절한 사유로 신고한 경우 불이익이 있을 수도 있습니다.",
+} as const;

--- a/src/features/report-review/model/useReportReview.ts
+++ b/src/features/report-review/model/useReportReview.ts
@@ -1,0 +1,1 @@
+export { useReportSteps as useReportReview } from "@/shared/ui/report";

--- a/src/features/report-review/ui/ReportReviewDialog.tsx
+++ b/src/features/report-review/ui/ReportReviewDialog.tsx
@@ -1,0 +1,34 @@
+import type { ReportTarget } from "@/shared/ui/report";
+import { ReportModal } from "@/shared/ui/report";
+import { REVIEW_REPORT_REASONS } from "../model/constants";
+import type { useReportReview } from "../model/useReportReview";
+
+const REVIEW_REPORT_CONFIG = {
+	targets: [
+		{ value: "user", label: "고객 리뷰 작성자" },
+		{ value: "post", label: "고객 리뷰 글" },
+	],
+	targetWarning:
+		"작성자를 신고할 경우 해당 사용자가 작성한 모든 리뷰가 비공개 처리됩니다",
+	reasons: (target: ReportTarget) => REVIEW_REPORT_REASONS[target ?? "post"],
+	reasonTitle: (target: ReportTarget) =>
+		target === "user"
+			? "작성자를 신고하는 사유를 선택해주세요"
+			: "고객 리뷰를 신고하는 사유를 선택해주세요",
+	doneTitle: (target: ReportTarget) =>
+		target === "user"
+			? "리뷰 작성자에 대한 신고가 완료되었습니다!"
+			: "리뷰의 신고가 완료되었습니다!",
+	doneBody: (target: ReportTarget) =>
+		target === "user"
+			? "신고 직후 해당 사용자가 작성한 모든 리뷰는 비공개 처리되며, 해당 사실이 작성자에게 고지되지 않습니다."
+			: "신고 직후 해당 리뷰는 비공개 처리되며, 부적절한 사유로 신고한 경우 불이익이 있을수도 있습니다",
+} as const;
+
+interface ReportReviewDialogProps {
+	state: ReturnType<typeof useReportReview>;
+}
+
+export function ReportReviewDialog({ state }: ReportReviewDialogProps) {
+	return <ReportModal state={state} config={REVIEW_REPORT_CONFIG} />;
+}

--- a/src/features/report-review/ui/ReportReviewDialog.tsx
+++ b/src/features/report-review/ui/ReportReviewDialog.tsx
@@ -1,29 +1,6 @@
-import type { ReportTarget } from "@/shared/ui/report";
 import { ReportModal } from "@/shared/ui/report";
-import { REVIEW_REPORT_REASONS } from "../model/constants";
+import { REVIEW_REPORT_CONFIG } from "../model/constants";
 import type { useReportReview } from "../model/useReportReview";
-
-const REVIEW_REPORT_CONFIG = {
-	targets: [
-		{ value: "user", label: "고객 리뷰 작성자" },
-		{ value: "post", label: "고객 리뷰 글" },
-	],
-	targetWarning:
-		"작성자를 신고할 경우 해당 사용자가 작성한 모든 리뷰가 비공개 처리됩니다",
-	reasons: (target: ReportTarget) => REVIEW_REPORT_REASONS[target ?? "post"],
-	reasonTitle: (target: ReportTarget) =>
-		target === "user"
-			? "작성자를 신고하는 사유를 선택해주세요"
-			: "고객 리뷰를 신고하는 사유를 선택해주세요",
-	doneTitle: (target: ReportTarget) =>
-		target === "user"
-			? "리뷰 작성자에 대한 신고가 완료되었습니다!"
-			: "리뷰의 신고가 완료되었습니다!",
-	doneBody: (target: ReportTarget) =>
-		target === "user"
-			? "신고 직후 해당 사용자가 작성한 모든 리뷰는 비공개 처리되며, 해당 사실이 작성자에게 고지되지 않습니다."
-			: "신고 직후 해당 리뷰는 비공개 처리되며, 부적절한 사유로 신고한 경우 불이익이 있을수도 있습니다",
-} as const;
 
 interface ReportReviewDialogProps {
 	state: ReturnType<typeof useReportReview>;

--- a/src/features/report-suggestion/ui/ReportSuggestionDialog.tsx
+++ b/src/features/report-suggestion/ui/ReportSuggestionDialog.tsx
@@ -10,7 +10,7 @@ const SUGGESTION_REPORT_CONFIG = {
 	],
 	targetWarning:
 		"사용자를 신고할 경우 해당 사용자가 작성한 모든 건의글이 삭제됩니다",
-	reasons: REPORT_REASONS,
+	reasons: () => REPORT_REASONS,
 	reasonTitle: (target: ReportTarget) =>
 		target === "user"
 			? "사용자를 신고하는 사유를 선택해주세요"

--- a/src/pages/partner/review/ui/PartnerReviewPage.tsx
+++ b/src/pages/partner/review/ui/PartnerReviewPage.tsx
@@ -21,6 +21,9 @@ const SORT_ITEMS: { label: string; value: SortType }[] = [
 	{ label: "별점순", value: "rating" },
 ];
 
+const averageRating =
+	mockReviews.reduce((sum, r) => sum + r.rating, 0) / mockReviews.length;
+
 const listContentStyle = {
 	gap: 20,
 	paddingHorizontal: 24,
@@ -78,10 +81,7 @@ export function PartnerReviewPage() {
 
 				<View className="mt-screen-m items-center">
 					<ReviewSummary
-						averageRating={
-							mockReviews.reduce((sum, r) => sum + r.rating, 0) /
-							mockReviews.length
-						}
+						averageRating={averageRating}
 						totalCount={mockReviews.length}
 					/>
 				</View>

--- a/src/pages/partner/review/ui/PartnerReviewPage.tsx
+++ b/src/pages/partner/review/ui/PartnerReviewPage.tsx
@@ -1,17 +1,25 @@
 // 고객리뷰 페이지 — 상단 고정 + 카드만 FlatList 스크롤
 
 import { router } from "expo-router";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FlatList, Pressable, Text, View } from "react-native";
 import { ReviewCard } from "@/entities/review";
+import { ReportReviewDialog, useReportReview } from "@/features/report-review";
 import { BackArrowIcon } from "@/shared/assets/icons";
 import { colorTokens } from "@/shared/styles/tokens";
+import { DarkSelectBottomSheet } from "@/shared/ui/bottom-sheet";
 import { InfoBanner } from "@/shared/ui/info/InfoBanner";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
 import { mockReviews } from "../model/mockReviews";
 import type { Review } from "../model/types";
 import { ReviewListHeader, type SortType } from "./ReviewListHeader";
 import { ReviewSummary } from "./ReviewSummary";
+
+const SORT_ITEMS: { label: string; value: SortType }[] = [
+	{ label: "최신순", value: "latest" },
+	{ label: "오래된순", value: "oldest" },
+	{ label: "별점순", value: "rating" },
+];
 
 const listContentStyle = {
 	gap: 20,
@@ -21,76 +29,93 @@ const listContentStyle = {
 
 export function PartnerReviewPage() {
 	const [sort, setSort] = useState<SortType>("latest");
+	const [isSortSheetVisible, setSortSheetVisible] = useState(false);
+	const report = useReportReview();
 
 	const sortedReviews = useMemo(() => {
-		return [...mockReviews].sort((a, b) =>
-			sort === "latest"
-				? b.createdAt.getTime() - a.createdAt.getTime()
-				: b.rating - a.rating,
-		);
+		return [...mockReviews].sort((a, b) => {
+			if (sort === "latest")
+				return b.createdAt.getTime() - a.createdAt.getTime();
+			if (sort === "oldest")
+				return a.createdAt.getTime() - b.createdAt.getTime();
+			return b.rating - a.rating;
+		});
 	}, [sort]);
 
-	const toggleSort = () =>
-		setSort((prev) => (prev === "latest" ? "rating" : "latest"));
+	const renderItem = useCallback(
+		({ item }: { item: Review }) => (
+			<ReviewCard
+				review={item}
+				action={{ label: "신고하기", onPress: () => report.open(item.id) }}
+			/>
+		),
+		[report],
+	);
 
 	return (
-		<PageLayout
-			className="flex-1 bg-canvas"
-			contentContainerClassName="flex-1"
-			withBottomInset
-		>
-			{/* 고정 상단 영역 */}
-			<View className="flex-row items-center px-gutter py-[12px]">
-				<Pressable onPress={() => router.back()} hitSlop={8}>
-					<BackArrowIcon
-						width={24}
-						height={24}
-						color={colorTokens.contentPrimary}
-					/>
-				</Pressable>
-				<View className="flex-1 items-center">
-					<Text className="text-[20px] font-semibold text-content-primary leading-caption tracking-caption">
-						고객리뷰
-					</Text>
+		<>
+			<PageLayout
+				className="flex-1 bg-canvas"
+				contentContainerClassName="flex-1"
+				withBottomInset
+			>
+				{/* 고정 상단 영역 */}
+				<View className="flex-row items-center px-gutter py-[12px]">
+					<Pressable onPress={() => router.back()} hitSlop={8}>
+						<BackArrowIcon
+							width={24}
+							height={24}
+							color={colorTokens.contentPrimary}
+						/>
+					</Pressable>
+					<View className="flex-1 items-center">
+						<Text className="text-[20px] font-semibold text-content-primary leading-caption tracking-caption">
+							고객리뷰
+						</Text>
+					</View>
+					<View className="w-[24px]" />
 				</View>
-				<View className="w-[24px]" />
-			</View>
 
-			<View className="mt-screen-m items-center">
-				<ReviewSummary
-					averageRating={
-						mockReviews.reduce((sum, r) => sum + r.rating, 0) /
-						mockReviews.length
-					}
-					totalCount={mockReviews.length}
-				/>
-			</View>
-
-			<View className="px-screen-m mt-gutter">
-				<InfoBanner message="제휴 혜택을 이용한 사용자들의 리뷰에요" />
-			</View>
-
-			<View className="mt-[16px] pb-[16px]">
-				<ReviewListHeader
-					count={sortedReviews.length}
-					sort={sort}
-					onToggleSort={toggleSort}
-				/>
-			</View>
-
-			{/* 카드 스크롤 영역 */}
-			<FlatList<Review>
-				style={{ flex: 1 }}
-				data={sortedReviews}
-				keyExtractor={(item) => item.id}
-				renderItem={({ item }) => (
-					<ReviewCard
-						review={item}
-						action={{ label: "신고하기", onPress: () => {} }}
+				<View className="mt-screen-m items-center">
+					<ReviewSummary
+						averageRating={
+							mockReviews.reduce((sum, r) => sum + r.rating, 0) /
+							mockReviews.length
+						}
+						totalCount={mockReviews.length}
 					/>
-				)}
-				contentContainerStyle={listContentStyle}
+				</View>
+
+				<View className="px-screen-m mt-gutter">
+					<InfoBanner message="제휴 혜택을 이용한 사용자들의 리뷰에요" />
+				</View>
+
+				<View className="mt-[16px] pb-[16px]">
+					<ReviewListHeader
+						count={sortedReviews.length}
+						sort={sort}
+						onPressSort={() => setSortSheetVisible(true)}
+					/>
+				</View>
+
+				{/* 카드 스크롤 영역 */}
+				<FlatList<Review>
+					style={{ flex: 1 }}
+					data={sortedReviews}
+					keyExtractor={(item) => item.id}
+					renderItem={renderItem}
+					contentContainerStyle={listContentStyle}
+				/>
+			</PageLayout>
+			<ReportReviewDialog state={report} />
+			<DarkSelectBottomSheet
+				visible={isSortSheetVisible}
+				title="정렬기준"
+				items={SORT_ITEMS}
+				value={sort}
+				onChange={setSort}
+				onClose={() => setSortSheetVisible(false)}
 			/>
-		</PageLayout>
+		</>
 	);
 }

--- a/src/pages/partner/review/ui/ReviewListHeader.tsx
+++ b/src/pages/partner/review/ui/ReviewListHeader.tsx
@@ -5,36 +5,37 @@ import { Ionicons } from "@expo/vector-icons";
 import { Pressable, Text, View } from "react-native";
 import { colorTokens } from "@/shared/styles/tokens";
 
-export type SortType = "latest" | "rating";
+export type SortType = "latest" | "oldest" | "rating";
 
 const SORT_LABEL: Record<SortType, string> = {
 	latest: "최신순",
+	oldest: "오래된순",
 	rating: "별점순",
 };
 
 interface Props {
 	count: number;
 	sort: SortType;
-	onToggleSort: () => void;
+	onPressSort: () => void;
 }
 
-export function ReviewListHeader({ count, sort, onToggleSort }: Props) {
+export function ReviewListHeader({ count, sort, onPressSort }: Props) {
 	return (
 		<View className="flex-row items-center justify-between px-screen-m">
 			<Text className="text-sm font-medium text-content-primary">
 				작성된 리뷰가 <Text className="text-primary">{count}</Text>건 있어요
 			</Text>
 			<Pressable
-				onPress={onToggleSort}
+				onPress={onPressSort}
 				hitSlop={8}
-				className="flex-row items-center gap-[4px]"
+				className="flex-row items-center gap-[5px]"
 			>
 				<Text className="text-sm font-medium text-content-primary">
 					{SORT_LABEL[sort]}
 				</Text>
 				<Ionicons
-					name="swap-vertical"
-					size={14}
+					name="chevron-down"
+					size={16}
 					color={colorTokens.contentPrimary}
 				/>
 			</Pressable>

--- a/src/shared/styles/tokens.ts
+++ b/src/shared/styles/tokens.ts
@@ -12,6 +12,8 @@ export const colorTokens = {
 	primary: "#0068FE",
 	/** global.styles.css: --color-primary-tint (blue-100) */
 	primaryTint: "#E5F6FE",
+	/** global.styles.css: --color-sub (blue-400) — dark 배경 위 선택 강조색 */
+	primaryOnDark: "#66A4FE",
 
 	/** global.styles.css: --color-neutral (gray-100) */
 	neutral: "#F4F4F5",

--- a/src/shared/ui/bottom-sheet/DarkSelectBottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/DarkSelectBottomSheet.tsx
@@ -1,0 +1,175 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef } from "react";
+import {
+	Animated,
+	Easing,
+	Modal,
+	PanResponder,
+	Platform,
+	Pressable,
+	Text,
+	View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { colorTokens } from "@/shared/styles/tokens";
+
+export type DarkSelectBottomSheetItem<T extends string = string> = {
+	label: string;
+	value: T;
+};
+
+type Props<T extends string = string> = {
+	visible: boolean;
+	title: string;
+	items: DarkSelectBottomSheetItem<T>[];
+	value: T;
+	onChange: (value: T) => void;
+	onClose: () => void;
+};
+
+const DISMISS_THRESHOLD = 80;
+
+export function DarkSelectBottomSheet<T extends string = string>({
+	visible,
+	title,
+	items,
+	value,
+	onChange,
+	onClose,
+}: Props<T>) {
+	const insets = useSafeAreaInsets();
+	const translateY = useRef(new Animated.Value(300)).current;
+	const onCloseRef = useRef(onClose);
+	onCloseRef.current = onClose;
+
+	useEffect(() => {
+		if (!visible) return;
+		translateY.setValue(300);
+		Animated.timing(translateY, {
+			toValue: 0,
+			duration: 200,
+			easing: Easing.out(Easing.quad),
+			useNativeDriver: true,
+		}).start();
+	}, [visible, translateY]);
+
+	const animateClose = () => {
+		Animated.timing(translateY, {
+			toValue: 400,
+			duration: 150,
+			easing: Easing.in(Easing.quad),
+			useNativeDriver: true,
+		}).start(() => onCloseRef.current());
+	};
+
+	const panResponder = useRef(
+		PanResponder.create({
+			onStartShouldSetPanResponder: () => true,
+			onMoveShouldSetPanResponder: (_, { dy }) => dy > 2,
+			onPanResponderMove: (_, { dy }) => {
+				if (dy > 0) translateY.setValue(dy);
+			},
+			onPanResponderRelease: (_, { dy, vy }) => {
+				if (dy > DISMISS_THRESHOLD || vy > 0.8) {
+					Animated.timing(translateY, {
+						toValue: 400,
+						duration: 150,
+						easing: Easing.in(Easing.quad),
+						useNativeDriver: true,
+					}).start(() => onCloseRef.current());
+				} else {
+					Animated.spring(translateY, {
+						toValue: 0,
+						useNativeDriver: true,
+						damping: 20,
+						stiffness: 250,
+					}).start();
+				}
+			},
+		}),
+	).current;
+
+	return (
+		<Modal
+			visible={visible}
+			transparent
+			animationType="none"
+			statusBarTranslucent={Platform.OS === "android"}
+			onRequestClose={animateClose}
+		>
+			<View className="flex-1 justify-end bg-[rgba(0,0,0,0.3)]">
+				<Pressable className="flex-1" onPress={animateClose} />
+				<Animated.View
+					{...panResponder.panHandlers}
+					className="rounded-t-[20px] pt-[40px]"
+					style={{
+						backgroundColor: colorTokens.contentPrimary,
+						paddingBottom: insets.bottom + 40,
+						transform: [{ translateY }],
+					}}
+				>
+					{/* 드래그 핸들 */}
+					<View className="items-center pb-[10px]">
+						<View
+							style={{
+								width: 36,
+								height: 5,
+								borderRadius: 100,
+								backgroundColor: "rgba(235, 235, 245, 0.3)",
+							}}
+						/>
+					</View>
+
+					<Text
+						className="font-bold px-[30px] py-[20px]"
+						style={{
+							fontSize: 15,
+							lineHeight: 21,
+							letterSpacing: -0.32,
+							color: colorTokens.contentInverse,
+						}}
+					>
+						{title}
+					</Text>
+
+					<View style={{ gap: 15 }}>
+						{items.map((item) => {
+							const isSelected = item.value === value;
+							return (
+								<Pressable
+									key={item.value}
+									className="flex-row items-center justify-between px-[30px]"
+									onPress={() => {
+										onChange(item.value);
+										animateClose();
+									}}
+								>
+									<Text
+										className="font-regular"
+										style={{
+											fontSize: 15,
+											lineHeight: 21,
+											letterSpacing: -0.32,
+											color: isSelected
+												? colorTokens.primaryOnDark
+												: colorTokens.contentInverse,
+										}}
+									>
+										{item.label}
+									</Text>
+									{isSelected && (
+										<Ionicons
+											name="checkmark"
+											size={24}
+											color={colorTokens.primaryOnDark}
+										/>
+									)}
+								</Pressable>
+							);
+						})}
+					</View>
+				</Animated.View>
+			</View>
+		</Modal>
+	);
+}

--- a/src/shared/ui/bottom-sheet/index.ts
+++ b/src/shared/ui/bottom-sheet/index.ts
@@ -1,1 +1,3 @@
 export { BottomActionSheet } from "./BottomActionSheet";
+export type { DarkSelectBottomSheetItem } from "./DarkSelectBottomSheet";
+export { DarkSelectBottomSheet } from "./DarkSelectBottomSheet";

--- a/src/shared/ui/report/ReportModal.tsx
+++ b/src/shared/ui/report/ReportModal.tsx
@@ -6,7 +6,9 @@ import type { useReportSteps } from "./useReportSteps";
 interface ReportModalConfig {
 	targets: readonly { value: string; label: string }[];
 	targetWarning: string;
-	reasons: readonly { value: string; label: string }[];
+	reasons: (
+		target: ReportTarget,
+	) => readonly { value: string; label: string }[];
 	reasonTitle: (target: ReportTarget) => string;
 	doneTitle: (target: ReportTarget) => string;
 	doneBody: (target: ReportTarget) => string;
@@ -62,7 +64,7 @@ export function ReportModal({ state, config }: ReportModalProps) {
 				<Dialog.Title>{config.reasonTitle(target)}</Dialog.Title>
 				<Dialog.Content>
 					<Dialog.RadioGroup value={reason} onChange={setReason}>
-						{config.reasons.map(({ value, label }) => (
+						{config.reasons(target).map(({ value, label }) => (
 							<Dialog.RadioItem key={value} value={value}>
 								{label}
 							</Dialog.RadioItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5233,6 +5233,72 @@ lan-network@^0.1.6:
   resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.7.tgz#9fcb9967c6d951f10b2f9a9ffabe4a312d63f69d"
   integrity sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==
 
+lefthook-darwin-arm64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.5.tgz#0ddb3dd9ad8441183dedb0c7d549a8ba3d9f8eac"
+  integrity sha512-VITTaw8PxxyE26gkZ8UcwIa5ZrWnKNRGLeeSrqri40cQdXvLTEoMq2tjjw7eiL9UcB0waRReDdzydevy9GOPUQ==
+
+lefthook-darwin-x64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.5.tgz#0d0ff3a545e7cc42d0b1a886c567859efcb04c70"
+  integrity sha512-AvtjYiW0BSGHBGrdvL313seUymrW9FxI+6JJwJ+ZSaa2sH81etrTB0wAwlH1L9VfFwK9+gWvatZBvLfF3L4fPw==
+
+lefthook-freebsd-arm64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.5.tgz#6d2e8570e2883b4c6c63b3c26424eb0451a60afd"
+  integrity sha512-mXjJwe8jKGWGiBYUxfQY1ab3Nn5NhafqT9q3KJz8m5joGGQj4JD0cbWxF1nVBLBWsDGbWZRZunTCMGcIScT2bQ==
+
+lefthook-freebsd-x64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.5.tgz#eb323b7e0a565b4ff92bd511476e79ac5ba97308"
+  integrity sha512-exD69dCjc1K45BxatDPGoH4NmEvgLKPm4kJLOWn1fTeHRKZwWiFPwnjknEoG2OemlCDHmCU++5X40kMEG0WBlA==
+
+lefthook-linux-arm64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.5.tgz#ef7f6e3ecf248261a20a21fd768f155787dfd48c"
+  integrity sha512-57TDKC5ewWpsCLZQKIJMHumFEObYKVundmPpiWhX491hINRZYYOL/26yrnVnNcidThRzTiTC+HLcuplLcaXtbA==
+
+lefthook-linux-x64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-linux-x64/-/lefthook-linux-x64-2.1.5.tgz#4cffc4a4c5414b7d79961e4b7626cdf5ec53d7ab"
+  integrity sha512-bqK3LrAB5l5YaCaoHk6qRWlITrGWzP4FbwRxA31elbxjd0wgNWZ2Sn3zEfSEcxz442g7/PPkEwqqsTx0kSFzpg==
+
+lefthook-openbsd-arm64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.5.tgz#a9fa773e35b5d00276da1b5e43fa730c604fa27f"
+  integrity sha512-5aSwK7vV3A6t0w9PnxCMiVjQlcvopBP50BtmnnLnNJyAYHnFbZ0Baq5M0WkE9IsUkWSux0fe6fd0jDkuG711MA==
+
+lefthook-openbsd-x64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.5.tgz#b5152036fd4ff39d421d53e37b8107dbc2946745"
+  integrity sha512-Y+pPdDuENJ8qWnUgL02xxhpjblc0WnwXvWGfqnl3WZrAgHzQpwx3G6469RID/wlNVdHYAlw3a8UkFSMYsTzXvA==
+
+lefthook-windows-arm64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.5.tgz#30b969159217c9f29c93455d1933aa2508b67a98"
+  integrity sha512-2PlcFBjTzJaMufw0c28kfhB/0zmaRCU0TRPPsil/HU2YNOExod4upPGLk9qjgsOmb2YVWFz6zq6u7+D1yqmzTQ==
+
+lefthook-windows-x64@2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook-windows-x64/-/lefthook-windows-x64-2.1.5.tgz#bc1c1a44deac500ebf5e3ee2d0fab5432eb67818"
+  integrity sha512-yiAh8qxml6uqy10jDxOdN9fOQpyLxBFY1fgCEAhn7sVJYmJKRhjqSBwZX6LG5MQjzr29KStrIdw7TR3lf3rT7Q==
+
+lefthook@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/lefthook/-/lefthook-2.1.5.tgz#6bee5acd8e3ad15b0e3ab6c9149cd5d1d1d8592f"
+  integrity sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A==
+  optionalDependencies:
+    lefthook-darwin-arm64 "2.1.5"
+    lefthook-darwin-x64 "2.1.5"
+    lefthook-freebsd-arm64 "2.1.5"
+    lefthook-freebsd-x64 "2.1.5"
+    lefthook-linux-arm64 "2.1.5"
+    lefthook-linux-x64 "2.1.5"
+    lefthook-openbsd-arm64 "2.1.5"
+    lefthook-openbsd-x64 "2.1.5"
+    lefthook-windows-arm64 "2.1.5"
+    lefthook-windows-x64 "2.1.5"
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,6 +1178,88 @@
     metro-transform-plugins "0.83.3"
     metro-transform-worker "0.83.3"
 
+"@expo/ngrok-bin-darwin-arm64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-darwin-arm64/-/ngrok-bin-darwin-arm64-2.3.40.tgz#f9306e15339dfe57a4bce07b4b0fb1a22d9bd35e"
+  integrity sha512-Zij81v/bIsVBvgXgYS71xbi/3lqKfVEfr7rId8BsHO3Ec1nQcp/I+729W3KX9PUHzWlXCLxOKZ3uF4jL/TcNbg==
+
+"@expo/ngrok-bin-darwin-x64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-darwin-x64/-/ngrok-bin-darwin-x64-2.3.40.tgz#86d64ad118d3e07b348636d3407dcf58ea746025"
+  integrity sha512-nqGLfxIjZBoT79VDk5mqaHQKCWkunSi486zGLeB8Ye8Qar1yo4STFwks+DqTbnGD5ItArQz2LzKRVE4YXuJFuw==
+
+"@expo/ngrok-bin-freebsd-ia32@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-freebsd-ia32/-/ngrok-bin-freebsd-ia32-2.3.40.tgz#86720a356658faea149489831a9d4952611d3f12"
+  integrity sha512-Ji3jZaOuIZO+ege23kZZAAEPUYkF+6mCpghb16b28Is1QHOSl2L4foDnAcWyzSEiBihMicxWltaQyaaxA0fdgw==
+
+"@expo/ngrok-bin-freebsd-x64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-freebsd-x64/-/ngrok-bin-freebsd-x64-2.3.40.tgz#16b6f456bb561c984711ce34b592b66f373a077e"
+  integrity sha512-mVnzKGQmOyXimZx6udoiyo3ZTYLZnPShlTySaDP0tqQ0vYz4ZscgvaYpMmDSPrsP/YG2owmKgzmOE2V+ycD8qA==
+
+"@expo/ngrok-bin-linux-arm64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-linux-arm64/-/ngrok-bin-linux-arm64-2.3.40.tgz#97d8404bf35c47f03a96635616c7b423db848478"
+  integrity sha512-S6kbnRqsVXHo/bWNxc0jfq33aQQRsGWjb6e7SvZ2DgXsPFLn27cfK0eHD96uCssARDVhzPsc+VU/B3d8C1DT5A==
+
+"@expo/ngrok-bin-linux-arm@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-linux-arm/-/ngrok-bin-linux-arm-2.3.40.tgz#a8342eb76c0d47dc208abec4c0cb548c2ac01fda"
+  integrity sha512-Je1QBd7x0hbZa4T3gZbVgD0cSzstpJ7Mu0+dM2lOB+vm3bd603yHtD0RlLdqARJFhPTE1M2zLd68gCEeZ5fRgQ==
+
+"@expo/ngrok-bin-linux-ia32@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-linux-ia32/-/ngrok-bin-linux-ia32-2.3.40.tgz#dad55f4fd5f223b1439fba4aa66d057b04349515"
+  integrity sha512-gPY5zv5Fu+TkCm5iZolXQbu7e5hc7fTllIKn/zJQxxZs/WCvSxyB5ip6vQcHiavu/kjr0HtNciPX/guXvWENkg==
+
+"@expo/ngrok-bin-linux-x64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-linux-x64/-/ngrok-bin-linux-x64-2.3.40.tgz#0038534284cf6db3e23e6cf412c855f04bd0f746"
+  integrity sha512-yOuwpOmMe6RGnk9ninlM7Zg1EiF81ptFOcFmT61PDOA4gK8/ttZKTMkDQiq0DZdcXUyE0HCr83EglJZTnHIzPA==
+
+"@expo/ngrok-bin-sunos-x64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-sunos-x64/-/ngrok-bin-sunos-x64-2.3.40.tgz#ffe19fa2142a7c3a87386903184638fcf6ad1651"
+  integrity sha512-0itEIQ7KsxRbF9nJk6tt0Ey+9TDC5H7krOsy3t7DPx01EvtaiEdMyhmE1XWjBtwr8+BaY9CpEhUWkx4iCcE4cw==
+
+"@expo/ngrok-bin-win32-ia32@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-win32-ia32/-/ngrok-bin-win32-ia32-2.3.40.tgz#d8f4e6123b160627a9b7662be183c89212fa366b"
+  integrity sha512-RAunwOAskfU0R5mYlxxB+bihLJ4nLRx5/x+q5nIq1muYmaqLvGtkQQHZKzgHJANJ7ZIbzfJY57IN2UICpibgIQ==
+
+"@expo/ngrok-bin-win32-x64@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin-win32-x64/-/ngrok-bin-win32-x64-2.3.40.tgz#d497c9cb5a235f5bc04d6b9df4474e2000cc0a61"
+  integrity sha512-a8xtUxX/Ftp2ho+/+VR5GCg0ttP9MNzYj58TVjfiKMkl4mVrbFVIzEinRzmy7PhiOWxqGQSCOdzEfa6C2G4nEA==
+
+"@expo/ngrok-bin@2.3.40":
+  version "2.3.40"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok-bin/-/ngrok-bin-2.3.40.tgz#bfdbd4a32fd71275d5153f859cb4594eec665de7"
+  integrity sha512-40GK1CY1QLPDHSQS7Fd36CJeZgMwtbeezkgp4tzfExVRVtWw30jOBCsM7TBB9IqEmmX7C/XwG47scMQHCnMw8A==
+  optionalDependencies:
+    "@expo/ngrok-bin-darwin-arm64" "2.3.40"
+    "@expo/ngrok-bin-darwin-x64" "2.3.40"
+    "@expo/ngrok-bin-freebsd-ia32" "2.3.40"
+    "@expo/ngrok-bin-freebsd-x64" "2.3.40"
+    "@expo/ngrok-bin-linux-arm" "2.3.40"
+    "@expo/ngrok-bin-linux-arm64" "2.3.40"
+    "@expo/ngrok-bin-linux-ia32" "2.3.40"
+    "@expo/ngrok-bin-linux-x64" "2.3.40"
+    "@expo/ngrok-bin-sunos-x64" "2.3.40"
+    "@expo/ngrok-bin-win32-ia32" "2.3.40"
+    "@expo/ngrok-bin-win32-x64" "2.3.40"
+
+"@expo/ngrok@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/ngrok/-/ngrok-4.1.0.tgz#d013ecc694c69132ba72d56562c42f7dc22bd517"
+  integrity sha512-PrtWxBt/SnOF1jZkf7oWznhEPFrmYKKeJPLVRKnEBd/y4eUYfoiNIXOzflIzhdrMubjWVI+pFuPJ6nkjVL95/Q==
+  dependencies:
+    "@expo/ngrok-bin" "2.3.40"
+    got "^11.5.1"
+    uuid "^3.3.2"
+    yaml "^1.10.0"
+
 "@expo/osascript@^2.3.8":
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@expo/osascript/-/osascript-2.3.8.tgz#6b376f09650e6476991f707356be54b5ea53d89e"
@@ -1858,6 +1940,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
+"@sindresorhus/is@^4.0.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
@@ -1969,6 +2056,13 @@
     deepmerge "^4.3.1"
     svgo "^3.0.2"
 
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
 "@tanstack/query-core@5.90.20":
   version "5.90.20"
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.90.20.tgz#e12128e39210715d4ce4fb299c33498ac297771e"
@@ -2026,6 +2120,16 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/cacheable-request@^6.0.1":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"
+  integrity sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "^3.1.4"
+    "@types/node" "*"
+    "@types/responselike" "^1.0.0"
+
 "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
@@ -2042,6 +2146,11 @@
   version "2.0.46"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
   integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
+
+"@types/http-cache-semantics@*":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#f6a7788f438cbfde15f29acad46512b4c01913b3"
+  integrity sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
@@ -2072,6 +2181,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/keyv@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
+  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-25.3.0.tgz#749b1bd4058e51b72e22bd41e9eab6ebd0180470"
@@ -2085,6 +2201,13 @@
   integrity sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==
   dependencies:
     csstype "^3.0.2"
+
+"@types/responselike@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.3.tgz#cc29706f0a397cfe6df89debfe4bf5cea159db50"
+  integrity sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -2846,6 +2969,24 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+
+cacheable-request@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
+  integrity sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -2991,6 +3132,13 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+clone-response@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
+  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -3283,6 +3431,13 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -3304,6 +3459,11 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
@@ -3458,6 +3618,13 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+end-of-stream@^1.1.0:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
@@ -4270,6 +4437,13 @@ get-proto@^1.0.0, get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
+get-stream@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
+
 get-symbol-description@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz#7bdd54e0befe8ffc9f3b4e203220d9f1e881b6ee"
@@ -4365,6 +4539,23 @@ gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+got@^11.5.1:
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
 
 graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
@@ -4469,6 +4660,11 @@ hosted-git-info@^7.0.0:
   dependencies:
     lru-cache "^10.0.1"
 
+http-cache-semantics@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
+
 http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
@@ -4479,6 +4675,14 @@ http-errors@~2.0.1:
     setprototypeof "~1.2.0"
     statuses "~2.0.2"
     toidentifier "~1.0.1"
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-proxy-agent@^7.0.5:
   version "7.0.6"
@@ -5012,7 +5216,7 @@ json5@^2.2.3:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-keyv@^4.5.4:
+keyv@^4.0.0, keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
@@ -5264,6 +5468,11 @@ lower-case@^2.0.2:
   integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
   dependencies:
     tslib "^2.0.3"
+
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
@@ -5761,6 +5970,16 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimatch@^10.2.2:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
@@ -5924,6 +6143,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
 npm-package-arg@^11.0.0:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-11.0.3.tgz#dae0c21199a99feca39ee4bfb074df3adac87e2d"
@@ -6050,7 +6274,7 @@ on-headers@~1.1.0:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
   integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -6113,6 +6337,11 @@ own-keys@^1.0.1:
     get-intrinsic "^1.2.6"
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
+
+p-cancelable@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
@@ -6417,6 +6646,14 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+pump@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
+  integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -6448,6 +6685,11 @@ queue@6.0.2:
   integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
   dependencies:
     inherits "~2.0.3"
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -6796,6 +7038,11 @@ reselect@^4.1.7:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
+resolve-alpn@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -6855,6 +7102,13 @@ resolve@~1.7.1:
   integrity sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==
   dependencies:
     path-parse "^1.0.5"
+
+responselike@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
+  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -7760,6 +8014,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
@@ -7987,6 +8246,11 @@ yallist@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
+
+yaml@^1.10.0:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yaml@^2.3.4, yaml@^2.6.1:
   version "2.8.2"


### PR DESCRIPTION
## 📝 요약                                                                                                                               
- 제휴업체 고객리뷰 신고 기능 - 구현 및 리뷰 정렬 바텀시트 추가, 신고 공통 로직을 shared로 분리                                          

## ⚙️ 작업 내용
  - `features/report-review` 신규 구현: 리뷰 작성자·리뷰 글 신고 다이얼로그 및 신고 사유 constants 작성
  - `shared/ui/bottom-sheet/DarkSelectBottomSheet` 신규 구현: 다크 배경 선택형 바텀시트 구현
  - `PartnerReviewPage` 리뷰 정렬을 토글 방식에서 바텀시트 선택 방식으로 변경 (`최신순 / 오래된순 / 별점순` 3가지)
  - `colorTokens.primaryOnDark` (#66A4FE) 신규 토큰 추가 

## 🔗 관련 이슈
  - Closes #82

## ✅ 체크리스트
  - [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
  - [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
  - [x] 변경 사항에 대한 테스트를 마쳤습니다.
  - [x] 불필요한 로그(console.log)를 제거하였습니다.

  ## 💬 리뷰어에게
  - **`shared/ui/bottom-sheet/DarkSelectBottomSheet`는 공용 컴포넌트입니다.** 다크 배경의 선택형 바텀시트가 필요한 곳
  (관리자 프로필 사진 수정 등)에서 가져다 쓸 수 있으니 필요하신 분은 활용해주세요. 

![1111](https://github.com/user-attachments/assets/f544646d-86be-4985-9664-be1e6f5e31f1)
![2222](https://github.com/user-attachments/assets/9758fc58-a83c-407c-8c9f-827deffed5a0)
![3333](https://github.com/user-attachments/assets/0e4855be-0c21-48e1-8ad6-28a3f4b54575)
![4444](https://github.com/user-attachments/assets/3928c11f-b56f-41c1-93af-58330837ebc7)


