### PR TITLE
[FEAT/#86] 채팅 내역 UI 구현

### DIFF
--- a/src/entities/chat/index.ts
+++ b/src/entities/chat/index.ts
@@ -3,4 +3,10 @@ export type {
 	Message,
 	MessageItemProps,
 } from "./model/types";
-export { ChatRoomItem, MessageBubble, MessageItem, MessageTime } from "./ui";
+export {
+	ChatRoomItem,
+	ChatRoomList,
+	MessageBubble,
+	MessageItem,
+	MessageTime,
+} from "./ui";

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -1,10 +1,12 @@
 import type { ImageSource } from "expo-image";
 
 export interface ChatRoomItemProps {
+	id: string;
 	profileImage: ImageSource;
 	roomName: string;
 	lastMessage: string;
 	unreadCount?: number;
+	onPress?: () => void;
 }
 
 export interface Message {

--- a/src/entities/chat/ui/ChatRoomItem.tsx
+++ b/src/entities/chat/ui/ChatRoomItem.tsx
@@ -1,5 +1,6 @@
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 
+import { colorTokens } from "@/shared/styles/tokens";
 import { ProfileAvatar } from "@/shared/ui/profile";
 
 import type { ChatRoomItemProps } from "../model/types";
@@ -9,35 +10,45 @@ export function ChatRoomItem({
 	roomName,
 	lastMessage,
 	unreadCount = 0,
+	onPress,
 }: ChatRoomItemProps) {
+	const displayCount = unreadCount > 99 ? "99+" : unreadCount; // 100 이상은 "99+"로 표시
 	return (
-		<View className="w-full flex-row items-center justify-between px-[10px] gap-[27px]">
-			{/* Left: profile + texts */}
-			<View className="flex-row shrink items-center gap-[27px]">
-				<ProfileAvatar source={profileImage} size={48} />
+		<Pressable onPress={onPress}>
+			{({ pressed }) => (
+				<View
+					className="w-full h-[70px] justify-center"
+					style={{ backgroundColor: pressed ? colorTokens.neutral : undefined }}
+				>
+					<View className="h-[48px] px-6 flex-row items-center justify-between gap-[27px]">
+						{/* 프로필 + 텍스트 영역 */}
+						<View className="ml-2 flex-row shrink items-center gap-[27px]">
+							<ProfileAvatar source={profileImage} size={48} />
+							{/* 텍스트 */}
+							<View className="shrink">
+								<Text className="font-bold text-[16px] leading-[22px] text-content-primary">
+									{roomName}
+								</Text>
+								<Text
+									className="font-regular text-[13px] leading-[22px] tracking-[-0.41px] text-content-secondary"
+									numberOfLines={1}
+								>
+									{lastMessage}
+								</Text>
+							</View>
+						</View>
 
-				{/* Text area */}
-				<View className="shrink">
-					<Text className="font-bold text-[16px] leading-[22px] text-content-primary">
-						{roomName}
-					</Text>
-					<Text
-						className="font-regular text-[13px] leading-[22px] tracking-[-0.41px] text-content-secondary"
-						numberOfLines={1}
-					>
-						{lastMessage}
-					</Text>
-				</View>
-			</View>
-
-			{/* Right: unread count badge */}
-			{unreadCount > 0 && (
-				<View className="rounded-full bg-primary justify-center px-[8px]">
-					<Text className="font-regular text-[12px] leading-[22px] tracking-[-0.41px] text-white">
-						{unreadCount}
-					</Text>
+						{/* 안읽은 메세지 카운트 뱃지 */}
+						{unreadCount > 0 && (
+							<View className="rounded-full bg-primary justify-center px-[8px]">
+								<Text className="font-regular text-[12px] leading-[22px] tracking-[-0.41px] text-white">
+									{displayCount}
+								</Text>
+							</View>
+						)}
+					</View>
 				</View>
 			)}
-		</View>
+		</Pressable>
 	);
 }

--- a/src/entities/chat/ui/ChatRoomItem.tsx
+++ b/src/entities/chat/ui/ChatRoomItem.tsx
@@ -14,7 +14,7 @@ export function ChatRoomItem({
 }: ChatRoomItemProps) {
 	const displayCount = unreadCount > 99 ? "99+" : unreadCount; // 100 이상은 "99+"로 표시
 	return (
-		<Pressable onPress={onPress}>
+		<Pressable onPress={onPress} disabled={!onPress}>
 			{({ pressed }) => (
 				<View
 					className="w-full h-[70px] justify-center"

--- a/src/entities/chat/ui/ChatRoomList.tsx
+++ b/src/entities/chat/ui/ChatRoomList.tsx
@@ -1,0 +1,36 @@
+import { FlatList, Pressable } from "react-native";
+
+import { EmptyState } from "@/shared/ui/empty-state";
+
+import type { ChatRoomItemProps } from "../model/types";
+import { ChatRoomItem } from "./ChatRoomItem";
+
+interface ChatRoomListProps {
+	rooms: ChatRoomItemProps[];
+	onPressRoom?: (id: string) => void;
+}
+
+export function ChatRoomList({ rooms, onPressRoom }: ChatRoomListProps) {
+	return (
+		<FlatList
+			data={rooms}
+			keyExtractor={(item) => item.id}
+			getItemLayout={(_, index) => ({
+				length: 70,
+				offset: 70 * index,
+				index,
+			})}
+			renderItem={({ item }) => (
+				<Pressable onPress={() => onPressRoom?.(item.id)}>
+					<ChatRoomItem {...item} />
+				</Pressable>
+			)}
+			ListEmptyComponent={
+				<EmptyState
+					title="아직 채팅 내역이 없어요"
+					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
+				/>
+			}
+		/>
+	);
+}

--- a/src/entities/chat/ui/ChatRoomList.tsx
+++ b/src/entities/chat/ui/ChatRoomList.tsx
@@ -1,4 +1,4 @@
-import { FlatList, Pressable } from "react-native";
+import { FlatList } from "react-native";
 
 import { EmptyState } from "@/shared/ui/empty-state";
 
@@ -21,9 +21,7 @@ export function ChatRoomList({ rooms, onPressRoom }: ChatRoomListProps) {
 				index,
 			})}
 			renderItem={({ item }) => (
-				<Pressable onPress={() => onPressRoom?.(item.id)}>
-					<ChatRoomItem {...item} />
-				</Pressable>
+				<ChatRoomItem {...item} onPress={() => onPressRoom?.(item.id)} />
 			)}
 			ListEmptyComponent={
 				<EmptyState

--- a/src/entities/chat/ui/index.ts
+++ b/src/entities/chat/ui/index.ts
@@ -1,4 +1,5 @@
 export { ChatRoomItem } from "./ChatRoomItem";
+export { ChatRoomList } from "./ChatRoomList";
 export { MessageBubble } from "./MessageBubble";
 export { MessageItem } from "./MessageItem";
 export { MessageTime } from "./MessageTime";

--- a/src/pages/admin/chat/model/mockChatRooms.ts
+++ b/src/pages/admin/chat/model/mockChatRooms.ts
@@ -1,0 +1,25 @@
+import type { ChatRoomItemProps } from "@/entities/chat";
+
+export const MOCK_ADMIN_CHAT_ROOMS: ChatRoomItemProps[] = [
+	{
+		id: "1",
+		profileImage: { uri: "https://picsum.photos/seed/store1/48" },
+		roomName: "인쌩맥주 숭실대점",
+		lastMessage: "제휴 협력 가능할까요?",
+		unreadCount: 1,
+	},
+	{
+		id: "2",
+		profileImage: { uri: "https://picsum.photos/seed/store2/48" },
+		roomName: "역전할머니맥주 숭실대점",
+		lastMessage: "감사합니다..!",
+		unreadCount: 200,
+	},
+	{
+		id: "3",
+		profileImage: { uri: "https://picsum.photos/seed/store3/48" },
+		roomName: "리얼후라이",
+		lastMessage: "잘 부탁드립니다",
+		unreadCount: 0,
+	},
+];

--- a/src/pages/admin/chat/ui/AdminChatPage.tsx
+++ b/src/pages/admin/chat/ui/AdminChatPage.tsx
@@ -1,34 +1,10 @@
-import { FlatList, View } from "react-native";
-
-import { ChatRoomItem, type ChatRoomItemProps } from "@/entities/chat";
-import { EmptyState } from "@/shared/ui/empty-state";
+import { View } from "react-native";
+import { ChatRoomList } from "@/entities/chat";
 import { PageLayout } from "@/shared/ui/layout";
 import { PageTitle } from "@/shared/ui/page-title";
 
-import { MOCK_ADMIN_CHAT_ROOMS } from "../model/mockChatRooms"; //목데이터
+import { MOCK_ADMIN_CHAT_ROOMS } from "../model/mockChatRooms";
 
-// 채팅방 리스트 로컬 컴포넌트
-function ChatRoomList({ rooms }: { rooms: ChatRoomItemProps[] }) {
-	return (
-		<FlatList
-			data={rooms}
-			keyExtractor={(item) => item.id}
-			getItemLayout={(_, index) => ({
-				length: 70,
-				offset: 70 * index,
-				index,
-			})}
-			renderItem={({ item }) => <ChatRoomItem {...item} />}
-			ListEmptyComponent={
-				<EmptyState
-					title="아직 채팅 내역이 없어요"
-					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
-				/>
-			}
-		/>
-	);
-}
-// PageLayout에 px-6을 적용하지 않은 이유: 디자인 상 채팅방 아이템이 화면 양 끝까지 닿아야 하기 때문
 export function AdminChatPage() {
 	return (
 		<PageLayout

--- a/src/pages/admin/chat/ui/AdminChatPage.tsx
+++ b/src/pages/admin/chat/ui/AdminChatPage.tsx
@@ -1,9 +1,46 @@
-import { Text, View } from "react-native";
+import { FlatList, View } from "react-native";
 
+import { ChatRoomItem, type ChatRoomItemProps } from "@/entities/chat";
+import { EmptyState } from "@/shared/ui/empty-state";
+import { PageLayout } from "@/shared/ui/layout";
+import { PageTitle } from "@/shared/ui/page-title";
+
+import { MOCK_ADMIN_CHAT_ROOMS } from "../model/mockChatRooms"; //목데이터
+
+// 채팅방 리스트 로컬 컴포넌트
+function ChatRoomList({ rooms }: { rooms: ChatRoomItemProps[] }) {
+	return (
+		<FlatList
+			data={rooms}
+			keyExtractor={(item) => item.id}
+			getItemLayout={(_, index) => ({
+				length: 70,
+				offset: 70 * index,
+				index,
+			})}
+			renderItem={({ item }) => <ChatRoomItem {...item} />}
+			ListEmptyComponent={
+				<EmptyState
+					title="아직 채팅 내역이 없어요"
+					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
+				/>
+			}
+		/>
+	);
+}
+// PageLayout에 px-6을 적용하지 않은 이유: 디자인 상 채팅방 아이템이 화면 양 끝까지 닿아야 하기 때문
 export function AdminChatPage() {
 	return (
-		<View className="flex-1 items-center justify-center bg-canvas">
-			<Text className="text-content-primary font-medium">관리자 채팅</Text>
-		</View>
+		<PageLayout
+			withTopInset={true}
+			withBottomInset={false}
+			className="flex-1 bg-canvas"
+			contentContainerClassName="flex-1 pt-6"
+		>
+			<View className="px-6">
+				<PageTitle title="채팅 내역" />
+			</View>
+			<ChatRoomList rooms={MOCK_ADMIN_CHAT_ROOMS} />
+		</PageLayout>
 	);
 }

--- a/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
+++ b/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
@@ -49,7 +49,7 @@ export function AdminDashboardPage() {
 				activeOpacity={0.8}
 				className="bg-primary items-center justify-center rounded-[8px] h-[41px]"
 				onPress={() => {
-					router.push("/(protected)/(admin)/partner-ship-suggestion-box");
+					router.push("/(protected)/admin/partner-ship-suggestion-box");
 				}}
 			>
 				<Text className="text-[11px] font-semibold text-content-inverse leading-caption tracking-caption">

--- a/src/pages/admin/home/ui/AdminHomePage.tsx
+++ b/src/pages/admin/home/ui/AdminHomePage.tsx
@@ -91,7 +91,7 @@ export function AdminHomePage() {
 				<PartnershipListWidget
 					partnerships={MOCK_PARTNERSHIPS}
 					onViewAll={() =>
-						router.push("/(protected)/(admin)/admin-partnership-list")
+						router.push("/(protected)/admin/admin-partnership-list")
 					}
 				/>
 

--- a/src/pages/customer-service/ui/CustomerServicePage.tsx
+++ b/src/pages/customer-service/ui/CustomerServicePage.tsx
@@ -1,14 +1,14 @@
-import type { SubmitHandler, UseFormHandleSubmit } from "react-hook-form";
-import { InquiryForm } from "@/features/inquiry-form";
-import { InquiryList } from "./InquiryList";
-import { AppTopBar } from "@/shared/ui/app-top-bar";
-import { PageLayout } from "@/shared/ui/layout";
-import { TabBar } from "@/shared/ui/TabBar";
-import { colorTokens } from "@/shared/styles/tokens";
 import { useRef, useState } from "react";
+import type { SubmitHandler, UseFormHandleSubmit } from "react-hook-form";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { InquiryFormData } from "@/features/inquiry-form";
+import { InquiryForm } from "@/features/inquiry-form";
+import { colorTokens } from "@/shared/styles/tokens";
+import { AppTopBar } from "@/shared/ui/app-top-bar";
+import { PageLayout } from "@/shared/ui/layout";
+import { TabBar } from "@/shared/ui/TabBar";
+import { InquiryList } from "./InquiryList";
 
 // Mock user data - 실제 auth 시스템 연결은 나중에
 const MOCK_USER = {

--- a/src/pages/customer-service/ui/InquiryItem.tsx
+++ b/src/pages/customer-service/ui/InquiryItem.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "expo-router";
 import { Pressable, Text, View } from "react-native";
-import { colorTokens } from "@/shared/styles/tokens";
 import type { Inquiry } from "@/entities/inquiry";
+import { colorTokens } from "@/shared/styles/tokens";
 
 interface InquiryItemProps {
 	inquiry: Inquiry;

--- a/src/pages/dev-hub/ui/DevHubPage.tsx
+++ b/src/pages/dev-hub/ui/DevHubPage.tsx
@@ -13,7 +13,7 @@ export function DevHubPage() {
 
 			<Pressable
 				className="mb-3 items-center rounded-lg bg-primary py-4"
-				onPress={() => router.push("/(protected)/(student)/(tabs)/home")}
+				onPress={() => router.push("/(protected)/student/(tabs)/home")}
 			>
 				<Text className="text-sm font-semibold text-white">
 					학생 홈으로 이동
@@ -22,7 +22,7 @@ export function DevHubPage() {
 
 			<Pressable
 				className="mb-3 items-center rounded-lg bg-primary py-4"
-				onPress={() => router.push("/(protected)/(admin)/(tabs)/home")}
+				onPress={() => router.push("/(protected)/admin/(tabs)/home")}
 			>
 				<Text className="text-sm font-semibold text-white">
 					관리자 홈으로 이동
@@ -31,7 +31,7 @@ export function DevHubPage() {
 
 			<Pressable
 				className="mb-6 items-center rounded-lg bg-primary py-4"
-				onPress={() => router.push("/(protected)/(partner)/(tabs)/home")}
+				onPress={() => router.push("/(protected)/partner/(tabs)/home")}
 			>
 				<Text className="text-sm font-semibold text-white">
 					제휴업체 홈으로 이동

--- a/src/pages/inquiry-detail/ui/InquiryDetailPage.tsx
+++ b/src/pages/inquiry-detail/ui/InquiryDetailPage.tsx
@@ -1,8 +1,14 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import {
+	ActivityIndicator,
+	Pressable,
+	ScrollView,
+	Text,
+	View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { BackArrowIcon } from "@/shared/assets/icons";
 import { colorTokens } from "@/shared/styles/tokens";
-import { useLocalSearchParams, useRouter } from "expo-router";
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
 import { useInquiryDetail } from "../api/useInquiryDetail";
 
 export function InquiryDetailPage() {
@@ -43,9 +49,7 @@ export function InquiryDetailPage() {
 			)}
 
 			{data && (
-				<ScrollView
-					contentContainerClassName="px-6 pt-7 pb-10"
-				>
+				<ScrollView contentContainerClassName="px-6 pt-7 pb-10">
 					{/* 제목 + 날짜 */}
 					<View className="items-center gap-0.5 mb-6">
 						<Text className="text-[18px] font-semibold text-content-primary tracking-[0.25px] text-center">

--- a/src/pages/partner/chat/model/mockChatRooms.ts
+++ b/src/pages/partner/chat/model/mockChatRooms.ts
@@ -1,0 +1,18 @@
+import type { ChatRoomItemProps } from "@/entities/chat";
+
+export const MOCK_PARTNER_CHAT_ROOMS: ChatRoomItemProps[] = [
+	{
+		id: "1",
+		profileImage: { uri: "https://picsum.photos/seed/admin1/48" },
+		roomName: "ASSU 운영진",
+		lastMessage: "제휴 조건 검토 중입니다.",
+		unreadCount: 2,
+	},
+	{
+		id: "2",
+		profileImage: { uri: "https://picsum.photos/seed/admin2/48" },
+		roomName: "ASSU 관리자",
+		lastMessage: "확인했습니다. 감사합니다!",
+		unreadCount: 0,
+	},
+];

--- a/src/pages/partner/chat/ui/PartnerChatPage.tsx
+++ b/src/pages/partner/chat/ui/PartnerChatPage.tsx
@@ -5,18 +5,10 @@ import { PageTitle } from "@/shared/ui/page-title";
 
 import { MOCK_PARTNER_CHAT_ROOMS } from "../model/mockChatRooms";
 
-// PageLayout에 px-6을 적용하지 않은 이유: 디자인 상 채팅방 아이템이 화면 양 끝까지 닿아야 하기 때문
 export function PartnerChatPage() {
 	return (
-		<PageLayout
-			withTopInset={true}
-			withBottomInset={false}
-			className="flex-1 bg-canvas"
-			contentContainerClassName="flex-1 px-6 pt-6"
-		>
-			<View className="px-6">
-				<PageTitle title="채팅 내역" />
-			</View>
+		<PageLayout contentContainerClassName="flex-1">
+			<PageTitle title="채팅 내역" />
 			<ChatRoomList rooms={MOCK_PARTNER_CHAT_ROOMS} />
 		</PageLayout>
 	);

--- a/src/pages/partner/chat/ui/PartnerChatPage.tsx
+++ b/src/pages/partner/chat/ui/PartnerChatPage.tsx
@@ -1,43 +1,17 @@
-import { FlatList, View } from "react-native";
-
-import { ChatRoomItem, type ChatRoomItemProps } from "@/entities/chat";
-import { EmptyState } from "@/shared/ui/empty-state";
+import { View } from "react-native";
+import { ChatRoomList } from "@/entities/chat";
 import { PageLayout } from "@/shared/ui/layout";
 import { PageTitle } from "@/shared/ui/page-title";
 
-import { MOCK_PARTNER_CHAT_ROOMS } from "../model/mockChatRooms"; // 목데이터
+import { MOCK_PARTNER_CHAT_ROOMS } from "../model/mockChatRooms";
 
-// 채팅방 리스트 로컬 컴포넌트
-function ChatRoomList({ rooms }: { rooms: ChatRoomItemProps[] }) {
-	return (
-		<FlatList
-			data={rooms}
-			keyExtractor={(item) => item.id}
-			getItemLayout={(_, index) => ({
-				length: 70,
-				offset: 70 * index,
-				index,
-			})}
-			renderItem={({ item }) => <ChatRoomItem {...item} />}
-			ListEmptyComponent={
-				<EmptyState
-					title="아직 채팅 내역이 없어요"
-					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
-				/>
-			}
-			contentContainerClassName="pt-2"
-		/>
-	);
-}
-
-// PageLayout에 px-6을 적용하지 않은 이유: 디자인 상 채팅방 아이템이 화면 양 끝까지 닿아야 하기 때문
 export function PartnerChatPage() {
 	return (
 		<PageLayout
 			withTopInset={true}
 			withBottomInset={false}
 			className="flex-1 bg-canvas"
-			contentContainerClassName="flex-1 pt-6"
+			contentContainerClassName="flex-1 px-6 pt-6"
 		>
 			<View className="px-6">
 				<PageTitle title="채팅 내역" />

--- a/src/pages/partner/chat/ui/PartnerChatPage.tsx
+++ b/src/pages/partner/chat/ui/PartnerChatPage.tsx
@@ -22,7 +22,7 @@ function ChatRoomList({ rooms }: { rooms: ChatRoomItemProps[] }) {
 			ListEmptyComponent={
 				<EmptyState
 					title="아직 채팅 내역이 없어요"
-					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
+					description={"운영진에게 제휴 관련 문의를\n시도할 수 있어요."}
 				/>
 			}
 			contentContainerClassName="pt-2"

--- a/src/pages/partner/chat/ui/PartnerChatPage.tsx
+++ b/src/pages/partner/chat/ui/PartnerChatPage.tsx
@@ -1,9 +1,48 @@
-import { Text, View } from "react-native";
+import { FlatList, View } from "react-native";
 
+import { ChatRoomItem, type ChatRoomItemProps } from "@/entities/chat";
+import { EmptyState } from "@/shared/ui/empty-state";
+import { PageLayout } from "@/shared/ui/layout";
+import { PageTitle } from "@/shared/ui/page-title";
+
+import { MOCK_PARTNER_CHAT_ROOMS } from "../model/mockChatRooms"; // 목데이터
+
+// 채팅방 리스트 로컬 컴포넌트
+function ChatRoomList({ rooms }: { rooms: ChatRoomItemProps[] }) {
+	return (
+		<FlatList
+			data={rooms}
+			keyExtractor={(item) => item.id}
+			getItemLayout={(_, index) => ({
+				length: 70,
+				offset: 70 * index,
+				index,
+			})}
+			renderItem={({ item }) => <ChatRoomItem {...item} />}
+			ListEmptyComponent={
+				<EmptyState
+					title="아직 채팅 내역이 없어요"
+					description={"제휴 협력을 원하는 매장에 채팅을\n시도 할 수 있어요!"}
+				/>
+			}
+			contentContainerClassName="pt-2"
+		/>
+	);
+}
+
+// PageLayout에 px-6을 적용하지 않은 이유: 디자인 상 채팅방 아이템이 화면 양 끝까지 닿아야 하기 때문
 export function PartnerChatPage() {
 	return (
-		<View className="flex-1 items-center justify-center bg-canvas">
-			<Text className="text-content-primary font-medium">업체 채팅</Text>
-		</View>
+		<PageLayout
+			withTopInset={true}
+			withBottomInset={false}
+			className="flex-1 bg-canvas"
+			contentContainerClassName="flex-1 pt-6"
+		>
+			<View className="px-6">
+				<PageTitle title="채팅 내역" />
+			</View>
+			<ChatRoomList rooms={MOCK_PARTNER_CHAT_ROOMS} />
+		</PageLayout>
 	);
 }

--- a/src/pages/partner/dashboard/ui/PartnerDashboardPage.tsx
+++ b/src/pages/partner/dashboard/ui/PartnerDashboardPage.tsx
@@ -6,7 +6,7 @@ export function PartnerDashboardPage() {
 		<View className="flex-1 items-center justify-center bg-canvas gap-gutter">
 			<Text className="text-content-primary font-medium">업체 대시보드</Text>
 			<Pressable
-				onPress={() => router.push("/(protected)/(partner)/review")}
+				onPress={() => router.push("/(protected)/partner/review")}
 				className="bg-primary px-screen-m py-card-p rounded-md items-center"
 			>
 				<Text className="text-content-inverse font-semibold text-md">

--- a/src/pages/partner/home/ui/PartnerHomePage.tsx
+++ b/src/pages/partner/home/ui/PartnerHomePage.tsx
@@ -38,7 +38,7 @@ export function PartnerHomePage() {
 					partnerships={MOCK_PARTNERSHIPS}
 					title="제휴단체 목록"
 					onViewAll={() =>
-						router.push("/(protected)/(partner)/partner-partnership-list")
+						router.push("/(protected)/partner/partner-partnership-list")
 					}
 				/>
 

--- a/src/pages/partnership-proposal/ui/PartnershipProposalPage.tsx
+++ b/src/pages/partnership-proposal/ui/PartnershipProposalPage.tsx
@@ -9,8 +9,8 @@ import {
 	ProposalInfoStep,
 	proposalSchema,
 } from "@/features/partnership-proposal";
-import { PageLayout } from "@/shared/ui/layout";
 import { AppTopBar } from "@/shared/ui/app-top-bar";
+import { PageLayout } from "@/shared/ui/layout";
 
 type Step = "step1" | "step2" | "complete";
 

--- a/src/pages/student/suggestion-form/model/useSuggestionForm.ts
+++ b/src/pages/student/suggestion-form/model/useSuggestionForm.ts
@@ -21,8 +21,7 @@ export function useSuggestionForm() {
 
 	const { mutate } = useMutation({
 		mutationFn: postSuggestion,
-		onSuccess: () =>
-			router.replace("/(protected)/(student)/suggestion-complete"),
+		onSuccess: () => router.replace("/(protected)/student/suggestion-complete"),
 		// TODO: API 연동 시 에러 핸들링 추가 (예: 토스트 메시지)
 	});
 

--- a/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
+++ b/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
@@ -56,9 +56,7 @@ export function StudentSuggestionPage() {
 						{count > COLLAPSED_LIMIT && (
 							<Pressable
 								onPress={() =>
-									router.push(
-										`/(protected)/(student)/benefit-all?month=${month}`,
-									)
+									router.push(`/(protected)/student/benefit-all?month=${month}`)
 								}
 							>
 								<Text className="font-regular text-sm text-content-secondary leading-caption tracking-caption">

--- a/src/pages/student/suggestion/ui/SuggestionSection.tsx
+++ b/src/pages/student/suggestion/ui/SuggestionSection.tsx
@@ -29,7 +29,7 @@ export function SuggestionSection() {
 				</View>
 				<Pressable
 					className="bg-primary py-card-p rounded-[12px] items-center"
-					onPress={() => router.push("/(protected)/(student)/suggestion-form")}
+					onPress={() => router.push("/(protected)/student/suggestion-form")}
 				>
 					<Text className="font-bold text-lg text-content-inverse leading-body tracking-body">
 						제휴 건의하기

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -21,7 +21,7 @@ export { default as SearchIcon } from "./search-icon.svg";
 export { default as SpeechBubbleIcon } from "./speech-bubble-icon.svg";
 export { default as StampActive } from "./stamp-active.svg";
 export { default as StampInactive } from "./stamp-inactive.svg";
-export { default as UploadFilesIcon } from "./upload-files-icon.svg";
 export { StarIcon } from "./star-icon";
+export { default as UploadFilesIcon } from "./upload-files-icon.svg";
 export { default as UserIcon } from "./user-icon.svg";
 export { default as WritingIcon } from "./writing-icon.svg";

--- a/src/shared/ui/app-top-bar/AppTopBar.tsx
+++ b/src/shared/ui/app-top-bar/AppTopBar.tsx
@@ -11,14 +11,20 @@ interface AppTopBarProps {
 export function AppTopBar({ title, onBack }: AppTopBarProps) {
 	return (
 		<View className="relative flex-row items-center justify-center px-screen-m pt-7 pb-4">
-			<Pressable hitSlop={8} onPress={onBack ?? (() => router.back())} className="absolute left-6">
+			<Pressable
+				hitSlop={8}
+				onPress={onBack ?? (() => router.back())}
+				className="absolute left-6"
+			>
 				<BackArrowIcon
 					width={24}
 					height={24}
 					color={colorTokens.contentPrimary}
 				/>
 			</Pressable>
-			<Text className="text-lg font-semibold text-content-primary">{title}</Text>
+			<Text className="text-lg font-semibold text-content-primary">
+				{title}
+			</Text>
 		</View>
 	);
 }

--- a/src/widgets/signup-user-flow/ui/SignupUserFlowWidget.tsx
+++ b/src/widgets/signup-user-flow/ui/SignupUserFlowWidget.tsx
@@ -166,7 +166,7 @@ export function SignupUserFlowWidget() {
 						<MediumButton
 							onPress={
 								step === "complete"
-									? () => router.replace("/(protected)/(student)/(tabs)/home")
+									? () => router.replace("/(protected)/student/(tabs)/home")
 									: goNext
 							}
 							disabled={isBottomDisabled}


### PR DESCRIPTION
## 📝 요약 
- 관리자, 제휴업체의 채팅 내역 UI 구현

## ⚙️ 작업 내용 
#### 1. `entities/chat/model/types.ts`

- `ChatRoomItemProps` 수정

#### 2. `entities/chat/ui/ChatRoomItem.tsx` - 채팅방 아이템

- 회색 배경으로 터치 피드백 추가
- 읽지 않은 메세지 개수가 100개 이상이면 "99+"로 표시

#### 3. `entities/chat/ui/ChatRoomList.tsx` - 채팅방 아이템 리스트
- 채팅방 아이템 리스트 컴포넌트
- `FlatList` + `getItemLayout` (length: 70, offset: 70 * index)
- 빈 상태 시 `EmptyState` 표시

---

#### 4. `pages/admin/chat/model/mockChatRooms.ts, pages/partner/chat/model/mockChatRooms.ts`

- 채팅내역 mock 데이터

#### 5. `pages/admin/chat/ui/AdminChatPage.tsx, pages/partner/chat/ui/PartnerChatPage.tsx`

- 채팅내역 페이지

---

<img width="300" src="https://github.com/user-attachments/assets/6e9de81d-ec5b-413d-801b-edc8192d8b71">

<img width="300" src="https://github.com/user-attachments/assets/89046660-a327-4423-a8db-7c91d0ddd3d6">

<img width="300" src="https://github.com/user-attachments/assets/d4859fff-e02c-47bd-a01d-63d381997a06">


## 🔗 관련 이슈 
- Closes #86 

## ✅ 체크리스트 
- [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
- [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
- [x] 변경 사항에 대한 테스트를 마쳤습니다.
- [x] 불필요한 로그(console.log)를 제거하였습니다.

## 💬 리뷰어에게 
- 나머지 파일들을 경로 수정과 바이옴관련 수정 사항입니다.