### PR TITLE
[FEAT/#100] web-hook 기반 카카오 맵 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/app.json
+++ b/app.json
@@ -9,9 +9,13 @@
 		"userInterfaceStyle": "automatic",
 		"newArchEnabled": true,
 		"ios": {
-			"supportsTablet": true
+			"supportsTablet": true,
+			"infoPlist": {
+				"NSLocationWhenInUseUsageDescription": "지도에서 내 위치를 표시하기 위해 위치 권한이 필요합니다."
+			}
 		},
 		"android": {
+			"permissions": ["android.permission.ACCESS_FINE_LOCATION"],
 			"adaptiveIcon": {
 				"backgroundColor": "#E6F4FE",
 				"foregroundImage": "./src/shared/assets/images/android-icon-foreground.png",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"expo-haptics": "~15.0.8",
 		"expo-image": "~3.0.11",
 		"expo-linking": "~8.0.11",
+		"expo-location": "~19.0.8",
 		"expo-router": "~6.0.23",
 		"expo-splash-screen": "~31.0.13",
 		"expo-status-bar": "~3.0.9",
@@ -47,6 +48,7 @@
 		"react-native-screens": "~4.16.0",
 		"react-native-svg": "15.12.1",
 		"react-native-web": "~0.21.0",
+		"react-native-webview": "13.15.0",
 		"react-native-worklets": "0.5.1",
 		"zod": "^4.3.6",
 		"zustand": "^5.0.11"

--- a/src/shared/ui/kakao-map/KakaoMap.tsx
+++ b/src/shared/ui/kakao-map/KakaoMap.tsx
@@ -1,0 +1,169 @@
+import {
+	forwardRef,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from "react";
+import { StyleSheet } from "react-native";
+import WebView, { type WebViewMessageEvent } from "react-native-webview";
+
+import { colorTokens } from "@/shared/styles/tokens";
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+	return {
+		r: Number.parseInt(hex.slice(1, 3), 16),
+		g: Number.parseInt(hex.slice(3, 5), 16),
+		b: Number.parseInt(hex.slice(5, 7), 16),
+	};
+}
+
+type KakaoMapProps = {
+	initialCenter?: { lat: number; lng: number };
+	myLocation?: { lat: number; lng: number } | null;
+	heading?: number | null;
+};
+
+export type KakaoMapHandle = {
+	panTo: (lat: number, lng: number) => void;
+};
+
+const SOONGSIL = { lat: 37.4963, lng: 126.9572 };
+
+export const KakaoMap = forwardRef<KakaoMapHandle, KakaoMapProps>(
+	function KakaoMap({ initialCenter = SOONGSIL, myLocation, heading }, ref) {
+		const appKey = process.env.EXPO_PUBLIC_KAKAO_JS_KEY ?? "";
+		const webViewRef = useRef<WebView>(null);
+		const [isMapReady, setIsMapReady] = useState(false);
+
+		useImperativeHandle(ref, () => ({
+			panTo: (lat, lng) => {
+				webViewRef.current?.injectJavaScript(
+					`map.panTo(new kakao.maps.LatLng(${lat}, ${lng})); true;`,
+				);
+			},
+		}));
+
+		// 탭 복귀 시 카메라 이동
+		useEffect(() => {
+			if (!isMapReady) return;
+			webViewRef.current?.injectJavaScript(`
+			map.setCenter(new kakao.maps.LatLng(${initialCenter.lat}, ${initialCenter.lng}));
+			map.setLevel(3);
+			true;
+		`);
+		}, [initialCenter, isMapReady]);
+
+		// 위치 변경 → 오버레이 생성 or 위치만 이동
+		useEffect(() => {
+			if (!isMapReady || !myLocation) return;
+			webViewRef.current?.injectJavaScript(
+				`window.updateMyLocation(${myLocation.lat}, ${myLocation.lng}); true;`,
+			);
+		}, [myLocation, isMapReady]);
+
+		// 방향 변경 → cone의 CSS transform만 교체 (DOM 재생성 없음)
+		useEffect(() => {
+			if (!isMapReady) return;
+			webViewRef.current?.injectJavaScript(
+				`window.updateHeading(${heading ?? "null"}); true;`,
+			);
+		}, [heading, isMapReady]);
+
+		const handleMessage = (event: WebViewMessageEvent) => {
+			try {
+				const data = JSON.parse(event.nativeEvent.data) as { type: string };
+				if (data.type === "MAP_READY") setIsMapReady(true);
+			} catch {}
+		};
+
+		return (
+			<WebView
+				ref={webViewRef}
+				source={{
+					html: buildMapHtml(appKey, initialCenter),
+					baseUrl: "http://localhost",
+				}}
+				style={StyleSheet.absoluteFill}
+				originWhitelist={["*"]}
+				javaScriptEnabled
+				scrollEnabled={false}
+				onMessage={handleMessage}
+			/>
+		);
+	},
+);
+
+function buildMapHtml(
+	appKey: string,
+	center: { lat: number; lng: number },
+): string {
+	const { r, g, b } = hexToRgb(colorTokens.primary);
+	const primary = colorTokens.primary;
+	const canvas = colorTokens.canvas;
+	const coneFill = `rgba(${r},${g},${b},0.35)`;
+	const ring = `rgba(${r},${g},${b},0.15)`;
+	return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #map { width: 100%; height: 100%; overflow: hidden; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>
+    var map;
+    var myLocationOverlay = null;
+
+    function createMyLocationOverlay(position) {
+      var content =
+        '<div style="position:relative;width:16px;height:16px;">' +
+          '<div id="loc-cone" style="position:absolute;bottom:8px;left:2px;width:12px;height:20px;transform-origin:6px 100%;transform:rotate(0deg);transition:transform 0.2s linear;">' +
+            '<svg width="12" height="20" viewBox="0 0 12 20" fill="${coneFill}"><polygon points="6,0 0,20 12,20"/></svg>' +
+          '</div>' +
+          '<div style="position:absolute;top:0;right:0;bottom:0;left:0;background:${primary};border:2.5px solid ${canvas};border-radius:50%;box-shadow:0 0 0 6px ${ring};"></div>' +
+        '</div>';
+      myLocationOverlay = new kakao.maps.CustomOverlay({
+        position: position,
+        content: content,
+        xAnchor: 0.5,
+        yAnchor: 0.5,
+        zIndex: 10
+      });
+      myLocationOverlay.setMap(map);
+    }
+
+    window.updateMyLocation = function(lat, lng) {
+      var position = new kakao.maps.LatLng(lat, lng);
+      if (myLocationOverlay) {
+        myLocationOverlay.setPosition(position);
+      } else {
+        createMyLocationOverlay(position);
+      }
+    };
+
+    window.updateHeading = function(heading) {
+      var cone = document.getElementById('loc-cone');
+      if (!cone || heading === null || heading === undefined) return;
+      cone.style.transform = 'rotate(' + heading + 'deg)';
+    };
+
+    function initMap() {
+      var initialPos = new kakao.maps.LatLng(${center.lat}, ${center.lng});
+      map = new kakao.maps.Map(document.getElementById('map'), {
+        center: initialPos,
+        level: 3
+      });
+      createMyLocationOverlay(initialPos);
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'MAP_READY' }));
+    }
+  </script>
+  <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false"></script>
+  <script>kakao.maps.load(initMap);</script>
+</body>
+</html>`;
+}

--- a/src/shared/ui/kakao-map/index.ts
+++ b/src/shared/ui/kakao-map/index.ts
@@ -1,0 +1,1 @@
+export { KakaoMap, type KakaoMapHandle } from "./KakaoMap";

--- a/src/widgets/map/model/useUserLocation.ts
+++ b/src/widgets/map/model/useUserLocation.ts
@@ -1,0 +1,63 @@
+import * as Location from "expo-location";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useRef, useState } from "react";
+
+const SOONGSIL = { lat: 37.4963, lng: 126.9572 };
+const HEADING_THRESHOLD_DEG = 5;
+
+type LatLng = { lat: number; lng: number };
+
+export function useUserLocation() {
+	const [center, setCenter] = useState<LatLng | null>(null);
+	const [myLocation, setMyLocation] = useState<LatLng | null>(null);
+	const [heading, setHeading] = useState<number | null>(null);
+	const lastHeadingRef = useRef<number | null>(null);
+
+	useFocusEffect(
+		useCallback(() => {
+			let positionSub: Location.LocationSubscription | undefined;
+			let headingSub: Location.LocationSubscription | undefined;
+
+			(async () => {
+				const { status } = await Location.requestForegroundPermissionsAsync();
+				if (status !== "granted") {
+					setCenter(SOONGSIL);
+					return;
+				}
+
+				const loc = await Location.getCurrentPositionAsync({});
+				const userLoc = { lat: loc.coords.latitude, lng: loc.coords.longitude };
+				setCenter(userLoc);
+				setMyLocation(userLoc);
+
+				positionSub = await Location.watchPositionAsync(
+					{
+						accuracy: Location.Accuracy.High,
+						timeInterval: 2000,
+						distanceInterval: 3,
+					},
+					(l) =>
+						setMyLocation({ lat: l.coords.latitude, lng: l.coords.longitude }),
+				);
+
+				headingSub = await Location.watchHeadingAsync((hdg) => {
+					const rounded = Math.round(hdg.magHeading);
+					if (
+						lastHeadingRef.current === null ||
+						Math.abs(rounded - lastHeadingRef.current) >= HEADING_THRESHOLD_DEG
+					) {
+						lastHeadingRef.current = rounded;
+						setHeading(rounded);
+					}
+				});
+			})();
+
+			return () => {
+				positionSub?.remove();
+				headingSub?.remove();
+			};
+		}, []),
+	);
+
+	return { center, myLocation, heading };
+}

--- a/src/widgets/map/ui/MapLocateButton.tsx
+++ b/src/widgets/map/ui/MapLocateButton.tsx
@@ -1,0 +1,32 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { shadows } from "@/shared/styles/shadows";
+import { colorTokens } from "@/shared/styles/tokens";
+
+const TOP_OFFSET_BELOW_SEARCH_BAR = 80;
+
+interface MapLocateButtonProps {
+	onPress: () => void;
+	disabled?: boolean;
+}
+
+export function MapLocateButton({ onPress, disabled }: MapLocateButtonProps) {
+	const insets = useSafeAreaInsets();
+
+	return (
+		<Pressable
+			onPress={onPress}
+			disabled={disabled}
+			className="absolute right-card-p flex-row items-center justify-center gap-gutter rounded-full bg-canvas p-gutter"
+			style={{
+				top: insets.top + TOP_OFFSET_BELOW_SEARCH_BAR,
+				...shadows.neutral,
+			}}
+			hitSlop={8}
+		>
+			<Ionicons name="locate" size={20} color={colorTokens.contentPrimary} />
+		</Pressable>
+	);
+}

--- a/src/widgets/map/ui/MapView.tsx
+++ b/src/widgets/map/ui/MapView.tsx
@@ -1,5 +1,34 @@
+import { useRef } from "react";
 import { View } from "react-native";
 
+import { KakaoMap, type KakaoMapHandle } from "@/shared/ui/kakao-map";
+import { useUserLocation } from "@/widgets/map/model/useUserLocation";
+
+import { MapLocateButton } from "./MapLocateButton";
+
 export function MapView() {
-	return <View className="flex-1 bg-neutral" />;
+	const kakaoRef = useRef<KakaoMapHandle>(null);
+	const { center, myLocation, heading } = useUserLocation();
+
+	const handleFocusToMyLocation = () => {
+		if (!myLocation) return;
+		kakaoRef.current?.panTo(myLocation.lat, myLocation.lng);
+	};
+
+	return (
+		<View className="flex-1 bg-canvas">
+			{center ? (
+				<KakaoMap
+					ref={kakaoRef}
+					initialCenter={center}
+					myLocation={myLocation}
+					heading={heading}
+				/>
+			) : null}
+			<MapLocateButton
+				onPress={handleFocusToMyLocation}
+				disabled={!myLocation}
+			/>
+		</View>
+	);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,6 +4085,11 @@ expo-linking@~8.0.11:
     expo-constants "~18.0.12"
     invariant "^2.2.4"
 
+expo-location@~19.0.8:
+  version "19.0.8"
+  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-19.0.8.tgz#1805393151b1286021c1ad36246b6fd095d09b55"
+  integrity sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==
+
 expo-modules-autolinking@3.0.24:
   version "3.0.24"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz#55fdfe1ef5a053d5cc287582170a5f6d69ab0e30"
@@ -4778,7 +4783,7 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -6916,6 +6921,14 @@ react-native-web@~0.21.0:
     nullthrows "^1.1.1"
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
+
+react-native-webview@13.15.0:
+  version "13.15.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.15.0.tgz#b6d2f8d8dd65897db76659ddd8198d2c74ec5a79"
+  integrity sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    invariant "2.2.4"
 
 react-native-worklets@0.5.1:
   version "0.5.1"


### PR DESCRIPTION
  ## 📝 요약                                                                                                                             
  - 학생/관리자/제휴업체 맵 탭에 카카오맵을 통합하고, 내 위치 표시·실시간 갱신·내 위치 포커스 기능을 추가합니다.
                                                                                                                                                                    
  ## ⚙️ 작업 내용                                                                                                                        ─
  - `shared/ui/kakao-map/KakaoMap.tsx`: react-native-webview 기반 카카오맵 컴포넌트 신규 추가. `forwardRef`로 `panTo(lat, lng)`        
  인터페이스를 노출하여 외부에서 카메라 이동 제어 가능.
  - 마커 생성 타이밍 개선: `initMap` 단계에서 내 위치 마커(파란 점 + 시야 cone)를 즉시 생성하도록 변경. 
  - `widgets/map/model/useUserLocation.ts`: 위치 권한·`watchPositionAsync`·`watchHeadingAsync` 로직을 훅으로 분리. `useFocusEffect`로 탭 포커스 단위 구독·해제.
  - `widgets/map/ui/MapLocateButton.tsx`: 우측 상단 위치 포커스 버튼 신규 컴포넌트. 누르면 어디를 보고 있든 `panTo`로 내 위치까지        
  부드럽게 카메라 이동. 
  설정. 
- `.gitignore`에 `.env` 추가.

  ## 🔗 관련 이슈
  - Closes #100

  ## ✅ 체크리스트
  - [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
  - [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
  - [x] 변경 사항에 대한 테스트를 마쳤습니다.
  - [x] 불필요한 로그(console.log)를 제거하였습니다.

  ## 💬 리뷰어에게

  ### ⚠️ 지도 회전 제스처 미지원 ⚠️ ###

  현재 구조는 **카카오맵 JavaScript SDK를 react-native-webview에 띄우는 방식**이라 두 손가락 회전 제스처를 SDK 차원에서 지원하지 않습니다. 카카오맵 모바일 앱이 회전되는 건 카카오 **네이티브 SDK** 기반이라 가능한 것인데 이 경우 저희 빌드 과정도 달라지고 별도의 추가적인 설정이 많이 필요하여 우선 웹훅 방식으로 구현하였습니다.

  회전을 적용하려면 `@react-native-kakao/map` 같은 네이티브 래퍼로 마이그레이션해야 하며, 이는 **단순 코드 변경이 아니라 팀 워크플로우 전환을 동반**합니다:

  - **Expo Go 사용 종료** → 팀 전체가 EAS dev client로 전환 (한 번 깔면 됨)
  - **카카오 디벨로퍼스 추가 설정**: Native App Key 신규 발급, Android 키 해시(디버그 + EAS 빌드용 각 1개), iOS 번들 ID 등록
  - **iOS 빌드는 Mac 또는 EAS 클라우드 필수**

  코드 작업 자체는 수정하면 되긴 하는데, 워크플로우 전환은 팀 회의에서 결정할 사안이라 본 PR에서는 의도적으로 보류했습니다.

  ### 기타 참고
  - 관리자/제휴 맵이 학생 대비 첫 진입에서 느려 보이는 현상이 있는데, 백그라운드에서 지도를 미리 로딩하는 개선은 **별도 PR로 분리 예정**입니다.

<img width="1440" height="2828" alt="image" src="https://github.com/user-attachments/assets/6933fbd6-cac9-458e-aa59-2e07ba072594" />
