### PR TITLE
[FEAT/#106] 메인 화면 API 연동 및 제휴 목록 상태 UI 처리

### DIFF
--- a/docs/decisions/ADR-001-async-state-ui-handling.md
+++ b/docs/decisions/ADR-001-async-state-ui-handling.md
@@ -1,0 +1,72 @@
+# ADR-001: 메인 화면 비동기 상태 UI 처리 패턴
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+메인 화면(AdminHomePage, PartnerHomePage)에서 제휴 목록 데이터를 fetch할 때, API 호출 결과가 error / empty / data 세 가지 상태로 나뉜다. 각 상태에 맞는 UI를 **어느 계층에서, 어떤 방식으로** 렌더링할 것인가를 결정해야 한다.
+
+## Decision Drivers
+
+- FSD 계층 원칙: 상위 계층(pages)이 하위 계층(widgets)의 내부 구현을 제어하지 않도록 한다.
+- 컴포넌트 책임 분리: 데이터를 소유하는 쪽이 상태를 처리한다.
+- 테스트 용이성: Widget을 독립적으로 테스트할 수 있어야 한다.
+- React Native(Expo) 환경 제약: Suspense for data fetching이 안정적으로 지원되지 않는다.
+
+## Considered Options
+
+- **A. Early Return 패턴** — 페이지에서 isError / empty를 분기하고, Widget은 유효한 데이터가 있을 때만 렌더링
+- **B. Suspense + Error Boundary 패턴** — `useSuspenseQuery`로 loading/error를 throw하고, 상위 경계에서 포착
+- **C. Widget에 상태 prop 전달** — `isError`, `isEmpty` 등을 Widget prop으로 전달하여 Widget 내부에서 UI 분기
+
+## Decision Outcome
+
+**Chosen option: A. Early Return 패턴**
+
+페이지가 fetch 상태를 소유하고 있으므로, 페이지에서 직접 분기하는 것이 책임 소재가 명확하다. Widget은 유효한 데이터를 받아 렌더링만 담당한다.
+
+```tsx
+// AdminHomePage
+const renderPartnershipSection = () => {
+    if (isPartnershipsError) return <EmptyState title="목록을 불러오지 못했어요" ... />;
+    if (partnerships.length === 0) return <EmptyState title="진행 중인 제휴가 없어요" ... />;
+    return <PartnershipListWidget partnerships={partnerships} maxItems={3} ... />;
+};
+```
+
+### Positive Consequences
+
+- Widget이 fetch 상태를 전혀 모르므로 순수 display 컴포넌트로 유지된다.
+- 상태별 UI를 페이지에서 한눈에 파악할 수 있다.
+- Widget을 props만으로 독립적으로 테스트할 수 있다.
+
+### Negative Consequences
+
+- 동일한 분기 로직(error/empty/data)이 AdminHomePage와 PartnerHomePage에 반복된다.
+- 페이지에 비동기 분기 코드가 늘어나 컴포넌트가 길어질 수 있다.
+
+## Pros and Cons of the Options
+
+### A. Early Return 패턴
+
+- Good: TanStack Query 공식 권장 패턴
+- Good: Widget이 `isError` 같은 fetch 관련 prop을 갖지 않아도 됨
+- Good: React Native 환경에서 안정적으로 동작
+- Bad: 페이지마다 동일한 분기 패턴을 반복 작성해야 함
+
+### B. Suspense + Error Boundary 패턴
+
+- Good: 선언적이고 컴포넌트가 단순해짐 (Next.js App Router 권장 방향)
+- Good: loading/error 처리가 컴포넌트 외부로 완전히 분리됨
+- Bad: React Native(Expo)에서 Suspense for data fetching 미완성
+- Bad: Expo Router와 Error Boundary 조합이 불안정한 케이스 존재
+- Bad: SSR Streaming과의 시너지가 핵심인데 React Native에는 SSR이 없음
+
+### C. Widget에 상태 prop 전달
+
+- Good: Widget 호출부 코드가 짧아짐
+- Bad: Widget이 fetch 계층의 관심사(isError)를 알게 되어 책임 경계가 모호해짐
+- Bad: Widget의 props가 비대해지고 테스트 시 상태 조합이 복잡해짐
+- Bad: FSD 원칙상 Widget은 UI 빌딩 블록이어야 하며 상태 관리 역할을 맡지 않는 것이 바람직함

--- a/docs/decisions/ADR-002-widget-pure-display-principle.md
+++ b/docs/decisions/ADR-002-widget-pure-display-principle.md
@@ -1,0 +1,75 @@
+# ADR-002: Widget은 순수 Display 컴포넌트로 설계한다
+
+## Status
+
+Accepted
+
+## Context and Problem Statement
+
+FSD 아키텍처에서 Widget 계층은 여러 페이지에서 공유하는 UI 블록이다. Widget이 데이터 fetch를 직접 담당해야 하는가(self-contained), 아니면 데이터를 props로 받아 렌더링만 담당해야 하는가(pure display)를 결정해야 한다.
+
+구체적인 계기: `PartnershipListWidget`에 `isError` prop을 추가하는 방식으로 구현했다가, Widget이 fetch 계층의 관심사를 알게 되는 문제를 발견하여 설계 원칙을 명문화한다.
+
+## Decision Drivers
+
+- FSD 계층 규칙: Widget은 상위 계층(pages, features)의 데이터를 받아 UI를 조합하는 역할이다.
+- 단일 책임 원칙: UI 렌더링과 데이터 fetch는 별개의 책임이다.
+- 재사용성: 동일한 Widget을 다양한 데이터 소스에서 사용할 수 있어야 한다.
+- 테스트 용이성: props만 주입하면 독립적으로 렌더링 테스트가 가능해야 한다.
+
+## Considered Options
+
+- **A. Pure Display Widget** — props로 데이터를 받고 렌더링만 담당. 비동기 상태는 외부(페이지)에서 처리.
+- **B. Self-Contained Widget** — Widget 내부에서 직접 fetch하고 loading/error/empty/data 상태를 모두 처리.
+
+## Decision Outcome
+
+**Chosen option: A. Pure Display Widget**
+
+현재 Widget들은 pages에서 fetch한 데이터를 props로 전달받는 구조다. 이 구조에서 Widget이 `isError` 같은 fetch 상태를 props로 받는 것은 책임 경계를 모호하게 만든다. 데이터를 소유하는 pages가 상태를 처리하고, Widget은 유효한 데이터를 렌더링하는 역할만 맡는다.
+
+```tsx
+// ✅ Pure display - fetch 상태를 모름
+<PartnershipListWidget
+    partnerships={partnerships}  // 유효한 데이터만 전달
+    maxItems={3}
+    onViewAll={...}
+    onPressCard={...}
+/>
+
+// ❌ Anti-pattern - fetch 계층의 관심사가 Widget으로 유입됨
+<PartnershipListWidget
+    partnerships={partnerships}
+    isError={isError}      // fetch 상태가 Widget prop으로 들어옴
+    isLoading={isLoading}
+/>
+```
+
+### Positive Consequences
+
+- Widget props가 UI 관련 값으로만 구성되어 인터페이스가 명확해진다.
+- 동일한 Widget을 mock 데이터, 실서버 데이터, 다른 API 응답 등 어디서든 재사용할 수 있다.
+- 스토리북 등에서 props만으로 모든 UI 상태를 재현할 수 있다.
+
+### Negative Consequences
+
+- Widget이 self-contained가 아니므로, 사용하는 페이지마다 fetch + 상태 분기 코드를 작성해야 한다.
+- 향후 Widget이 복잡해져 자체 fetch가 필요해지면 설계를 변경해야 한다.
+
+## Pros and Cons of the Options
+
+### A. Pure Display Widget
+
+- Good: 단일 책임 원칙 준수 — 렌더링만 담당
+- Good: FSD Widget 계층의 의도에 부합
+- Good: props 기반 테스트 용이
+- Bad: 페이지가 fetch + 분기 + Widget 호출을 모두 담당하여 코드량 증가
+
+### B. Self-Contained Widget
+
+- Good: Widget 단독으로 어디서든 사용 가능 (plug-and-play)
+- Good: 페이지 코드가 단순해짐
+- Bad: Widget이 특정 API에 결합되어 재사용성이 낮아짐
+- Bad: fetch 로직 변경 시 Widget 내부를 수정해야 함
+- Bad: 동일 Widget을 다른 데이터 소스로 테스트하기 어려움
+- Bad: FSD에서 Widget은 features/entities를 조합하는 UI 블록으로 정의되며, 직접 API를 호출하는 것은 과도한 책임

--- a/src/entities/partnership/api/getAdminPartnerRecommend.ts
+++ b/src/entities/partnership/api/getAdminPartnerRecommend.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type {
+	AdminRecommendResponseDTO,
+	BaseResponse,
+} from "../model/api-types";
+
+async function fetchAdminPartnerRecommend(): Promise<AdminRecommendResponseDTO> {
+	const res = await apiInstance.get<BaseResponse<AdminRecommendResponseDTO>>(
+		"/admin/partner-recommend",
+	);
+	return res.data.result;
+}
+
+export function useAdminPartnerRecommend() {
+	return useQuery({
+		queryKey: ["admin", "partner-recommend"],
+		queryFn: fetchAdminPartnerRecommend,
+	});
+}

--- a/src/entities/partnership/api/getAdminPartnerships.ts
+++ b/src/entities/partnership/api/getAdminPartnerships.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type {
+	BaseResponse,
+	PagedResponse,
+	WritePartnershipResponseDTO,
+} from "../model/api-types";
+
+async function fetchAdminPartnerships(): Promise<
+	PagedResponse<WritePartnershipResponseDTO>
+> {
+	const res =
+		await apiInstance.get<
+			BaseResponse<PagedResponse<WritePartnershipResponseDTO>>
+		>("/partnership/admin");
+	return res.data.result;
+}
+
+export function useAdminPartnerships() {
+	return useQuery({
+		queryKey: ["partnership", "admin"],
+		queryFn: fetchAdminPartnerships,
+	});
+}

--- a/src/entities/partnership/api/getPartnerAdminRecommend.ts
+++ b/src/entities/partnership/api/getPartnerAdminRecommend.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type {
+	BaseResponse,
+	PartnerRecommendResponseDTO,
+} from "../model/api-types";
+
+async function fetchPartnerAdminRecommend(): Promise<PartnerRecommendResponseDTO> {
+	const res = await apiInstance.get<BaseResponse<PartnerRecommendResponseDTO>>(
+		"/partner/admin-recommend",
+	);
+	return res.data.result;
+}
+
+export function usePartnerAdminRecommend() {
+	return useQuery({
+		queryKey: ["partner", "admin-recommend"],
+		queryFn: fetchPartnerAdminRecommend,
+	});
+}

--- a/src/entities/partnership/api/getPartnerPartnerships.ts
+++ b/src/entities/partnership/api/getPartnerPartnerships.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type {
+	BaseResponse,
+	PagedResponse,
+	WritePartnershipResponseDTO,
+} from "../model/api-types";
+
+async function fetchPartnerPartnerships(): Promise<
+	PagedResponse<WritePartnershipResponseDTO>
+> {
+	const res = await apiInstance.get<
+		BaseResponse<PagedResponse<WritePartnershipResponseDTO>>
+	>("/partnership/partner");
+	return res.data.result;
+}
+
+export function usePartnerPartnerships() {
+	return useQuery({
+		queryKey: ["partnership", "partner"],
+		queryFn: fetchPartnerPartnerships,
+	});
+}

--- a/src/entities/partnership/api/getPartnershipDetail.ts
+++ b/src/entities/partnership/api/getPartnershipDetail.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type {
+	BaseResponse,
+	PartnershipDetailResponseDTO,
+} from "../model/api-types";
+
+async function fetchPartnershipDetail(
+	id: string,
+): Promise<PartnershipDetailResponseDTO> {
+	const res = await apiInstance.get<BaseResponse<PartnershipDetailResponseDTO>>(
+		`/partnership/${id}`,
+	);
+	return res.data.result;
+}
+
+export function usePartnershipDetail(id: string | null) {
+	return useQuery({
+		queryKey: ["partnership", "detail", id],
+		queryFn: () => fetchPartnershipDetail(id as string),
+		enabled: id !== null,
+	});
+}

--- a/src/entities/partnership/api/index.ts
+++ b/src/entities/partnership/api/index.ts
@@ -1,0 +1,5 @@
+export { useAdminPartnerRecommend } from "./getAdminPartnerRecommend";
+export { useAdminPartnerships } from "./getAdminPartnerships";
+export { usePartnerAdminRecommend } from "./getPartnerAdminRecommend";
+export { usePartnerPartnerships } from "./getPartnerPartnerships";
+export { usePartnershipDetail } from "./getPartnershipDetail";

--- a/src/entities/partnership/index.ts
+++ b/src/entities/partnership/index.ts
@@ -1,3 +1,30 @@
+export {
+	useAdminPartnerRecommend,
+	useAdminPartnerships,
+	usePartnerAdminRecommend,
+	usePartnerPartnerships,
+	usePartnershipDetail,
+} from "./api";
+export type {
+	AdminAffiliationSummary,
+	PartnerAffiliationSummary,
+} from "./lib/adapters";
+export {
+	toAdminAffiliationSummary,
+	toPartnerAffiliationSummary,
+	toPartnership,
+	toPartnershipContract,
+} from "./lib/adapters";
+export type {
+	AdminLiteDTO,
+	AdminRecommendResponseDTO,
+	BaseResponse,
+	PagedResponse,
+	PartnerRecommendResponseDTO,
+	PartnershipDetailResponseDTO,
+	PartnershipOptionDTO,
+	WritePartnershipResponseDTO,
+} from "./model/api-types";
 export { MOCK_ADMIN_AFFILIATION_SUMMARY } from "./model/mockAdminAffiliationSummary";
 export { MOCK_PARTNER_AFFILIATION_SUMMARIES } from "./model/mockPartnerAffiliationSummaries";
 export { MOCK_PARTNERSHIPS } from "./model/mockPartnerships";

--- a/src/entities/partnership/lib/adapters.ts
+++ b/src/entities/partnership/lib/adapters.ts
@@ -1,0 +1,118 @@
+import type {
+	AdminLiteDTO,
+	AdminRecommendResponseDTO,
+	PartnershipDetailResponseDTO,
+	WritePartnershipResponseDTO,
+} from "../model/api-types";
+import type {
+	BenefitItem,
+	DiscountBenefitItem,
+	EtcBenefitItem,
+	Partnership,
+	PartnershipContract,
+	ServiceBenefitItem,
+} from "../model/types";
+
+export interface AdminAffiliationSummary {
+	title: string;
+	address: string;
+	partnerUrl?: string;
+	status?: "제휴중" | "제휴예정";
+	dateRange?: string;
+}
+
+export interface PartnerAffiliationSummary {
+	title: string;
+	address: string;
+}
+
+export function toPartnership(dto: WritePartnershipResponseDTO): Partnership {
+	const firstOption = dto.options[0];
+	const benefitContent = firstOption?.note ?? firstOption?.category ?? "";
+
+	return {
+		id: dto.partnershipId.toString(),
+		storeName: dto.storeName,
+		benefitContent,
+		startDate: dto.partnershipPeriodStart,
+		endDate: dto.partnershipPeriodEnd,
+	};
+}
+
+function toBenefitItem(
+	option: PartnershipDetailResponseDTO["options"][number],
+	index: number,
+): BenefitItem {
+	const id = `option-${index}`;
+
+	if (option.anotherType) {
+		const item: EtcBenefitItem = {
+			id,
+			serviceType: "기타 혜택",
+			content: option.note ?? "",
+		};
+		return item;
+	}
+
+	if (option.optionType === "DISCOUNT") {
+		const item: DiscountBenefitItem = {
+			id,
+			serviceType: "할인 혜택",
+			criteria: option.criterionType === "PRICE" ? "금액" : "인원수",
+			amount: option.cost?.toString() ?? "",
+			minCount: option.people?.toString() ?? "",
+			discountRate: option.discountRate?.toString() ?? "",
+		};
+		return item;
+	}
+
+	const item: ServiceBenefitItem = {
+		id,
+		serviceType: "서비스 제공",
+		criteria: option.criterionType === "PRICE" ? "금액" : "인원수",
+		amount: option.cost?.toString() ?? "",
+		minCount: option.people?.toString() ?? "",
+		categories: option.category ? [option.category] : [],
+		items: option.goods.map((g) => g.goodsName),
+	};
+	return item;
+}
+
+export function toPartnershipContract(
+	dto: PartnershipDetailResponseDTO,
+): PartnershipContract {
+	return {
+		id: dto.partnershipId.toString(),
+		companyName: "",
+		proposerName: "",
+		benefits: dto.options.map(toBenefitItem),
+		startDate: dto.partnershipPeriodStart,
+		endDate: dto.partnershipPeriodEnd,
+		contractDate: dto.updatedAt.substring(0, 10),
+	};
+}
+
+export function toAdminAffiliationSummary(
+	dto: AdminRecommendResponseDTO,
+): AdminAffiliationSummary {
+	const addressParts = [dto.partnerAddress, dto.partnerDetailAddress].filter(
+		Boolean,
+	);
+	return {
+		title: dto.partnerName,
+		address: addressParts.join(" "),
+		partnerUrl: dto.partnerUrl,
+	};
+}
+
+export function toPartnerAffiliationSummary(
+	dto: AdminLiteDTO,
+): PartnerAffiliationSummary {
+	const addressParts = [dto.adminAddress, dto.adminDetailAddress].filter(
+		Boolean,
+	);
+	return {
+		title: dto.adminName,
+		address: addressParts.join(" "),
+	};
+}

--- a/src/entities/partnership/lib/index.ts
+++ b/src/entities/partnership/lib/index.ts
@@ -1,0 +1,10 @@
+export type {
+	AdminAffiliationSummary,
+	PartnerAffiliationSummary,
+} from "./adapters";
+export {
+	toAdminAffiliationSummary,
+	toPartnerAffiliationSummary,
+	toPartnership,
+	toPartnershipContract,
+} from "./adapters";

--- a/src/entities/partnership/model/api-types.ts
+++ b/src/entities/partnership/model/api-types.ts
@@ -1,0 +1,75 @@
+export interface PartnershipOptionDTO {
+	optionType: "SERVICE" | "DISCOUNT";
+	criterionType: "PRICE" | "HEADCOUNT";
+	anotherType: boolean;
+	people?: number;
+	cost?: number;
+	note?: string;
+	category?: string;
+	discountRate?: number;
+	goods: { goodsId: number; goodsName: string }[];
+}
+
+export interface WritePartnershipResponseDTO {
+	partnershipId: number;
+	partnershipPeriodStart: string;
+	partnershipPeriodEnd: string;
+	adminId: number;
+	partnerId: number | null;
+	storeId: number;
+	storeName: string;
+	adminName: string;
+	isActivated: "ACTIVE" | "INACTIVE" | "SUSPEND" | "BLANK";
+	options: PartnershipOptionDTO[];
+}
+
+export interface PartnershipDetailResponseDTO {
+	partnershipId: number;
+	updatedAt: string;
+	partnershipPeriodStart: string;
+	partnershipPeriodEnd: string;
+	adminId: number;
+	partnerId: number | null;
+	storeId: number;
+	options: PartnershipOptionDTO[];
+}
+
+export interface PagedResponse<T> {
+	content: T[];
+	totalPages: number;
+	totalElements: number;
+	size: number;
+	number: number;
+	first: boolean;
+	last: boolean;
+	empty: boolean;
+}
+
+export interface AdminRecommendResponseDTO {
+	partnerId: number;
+	partnerName: string;
+	partnerAddress: string;
+	partnerDetailAddress?: string;
+	partnerUrl?: string;
+	partnerPhone?: string;
+}
+
+export interface AdminLiteDTO {
+	adminId: number;
+	adminName: string;
+	adminAddress: string;
+	adminDetailAddress?: string;
+	adminUrl?: string;
+	adminPhone?: string;
+}
+
+export interface PartnerRecommendResponseDTO {
+	admins: AdminLiteDTO[];
+}
+
+export interface BaseResponse<T> {
+	isSuccess: boolean;
+	code: string;
+	message: string;
+	result: T;
+}

--- a/src/pages/admin/admin-partnership-list/ui/PartnerListPage.tsx
+++ b/src/pages/admin/admin-partnership-list/ui/PartnerListPage.tsx
@@ -1,8 +1,12 @@
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import { MOCK_PARTNERSHIPS } from "@/entities/partnership";
-import { MOCK_PARTNERSHIP_CONTRACTS } from "@/entities/partnership/model/mockPartnershipContracts";
+import {
+	toPartnership,
+	toPartnershipContract,
+	useAdminPartnerships,
+	usePartnershipDetail,
+} from "@/entities/partnership";
 import { PartnershipContractModal } from "@/features/partnership-contract";
 import { BackArrowIcon, InfoFillIcon } from "@/shared/assets/icons";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
@@ -47,8 +51,13 @@ export function PartnerListPage() {
 		null,
 	);
 
-	const selectedContract =
-		MOCK_PARTNERSHIP_CONTRACTS.find((c) => c.id === selectedContractId) ?? null;
+	const { data: partnershipsData } = useAdminPartnerships();
+	const partnerships = partnershipsData?.content.map(toPartnership) ?? [];
+
+	const { data: detailData } = usePartnershipDetail(selectedContractId);
+	const selectedContract = detailData
+		? toPartnershipContract(detailData)
+		: null;
 
 	return (
 		<>
@@ -61,9 +70,9 @@ export function PartnerListPage() {
 			>
 				<Header onBack={() => router.back()} />
 				<InfoBox />
-				<CountSection count={MOCK_PARTNERSHIPS.length} />
+				<CountSection count={partnerships.length} />
 				<PartnershipListContent
-					data={MOCK_PARTNERSHIPS}
+					data={partnerships}
 					onPressCard={(id) => setSelectedContractId(id)}
 				/>
 			</PageLayout>

--- a/src/pages/admin/home/ui/AdminHomePage.tsx
+++ b/src/pages/admin/home/ui/AdminHomePage.tsx
@@ -1,20 +1,20 @@
 import { useRouter } from "expo-router";
 import { Pressable, Text, View } from "react-native";
 import {
-	MOCK_ADMIN_AFFILIATION_SUMMARY,
-	MOCK_PARTNERSHIPS,
+	toAdminAffiliationSummary,
+	toPartnership,
+	useAdminPartnerRecommend,
+	useAdminPartnerships,
 } from "@/entities/partnership";
 import { BellFill, Logo } from "@/shared/assets/icons";
+import { EmptyState } from "@/shared/ui/empty-state";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
 import { PageTitle } from "@/shared/ui/page-title";
 import { SummaryCard } from "@/shared/ui/summary-card";
 import { PartnershipListWidget } from "@/widgets/partnership-list";
-import { MOCK_ADMIN_PAGE_INFO } from "../model/mockAdminPageInfo";
 
-// No-op for stable callback reference
 const noop = () => {};
 
-// Admin header section component
 function AdminHeaderSection({
 	onNotificationPress,
 }: {
@@ -30,31 +30,29 @@ function AdminHeaderSection({
 	);
 }
 
-// Recommendation section component
 function RecommendationSection() {
+	const { data } = useAdminPartnerRecommend();
+	const summary = data ? toAdminAffiliationSummary(data) : null;
+
+	if (!summary) return null;
+
 	return (
 		<View className="gap-2">
 			<Text className="text-lg font-medium text-content-primary">
 				🔍 제휴업체 추천
 			</Text>
 			<SummaryCard
-				imageUrl={MOCK_ADMIN_AFFILIATION_SUMMARY?.imageUrl}
-				title={MOCK_ADMIN_AFFILIATION_SUMMARY?.title || ""}
-				subtitle={MOCK_ADMIN_AFFILIATION_SUMMARY?.address || ""}
-				status={MOCK_ADMIN_AFFILIATION_SUMMARY?.status}
-				dateRange={MOCK_ADMIN_AFFILIATION_SUMMARY?.dateRange}
-				actionLabel={
-					MOCK_ADMIN_AFFILIATION_SUMMARY?.status === "제휴중"
-						? "제휴 계약서 보기"
-						: "문의하기"
-				}
+				title={summary.title}
+				subtitle={summary.address}
+				status={summary.status}
+				dateRange={summary.dateRange}
+				actionLabel="문의하기"
 				onActionPress={noop}
 			/>
 		</View>
 	);
 }
 
-// Manual registration button component
 function ManualRegistrationButton({ onPress }: { onPress: () => void }) {
 	return (
 		<Pressable
@@ -70,6 +68,40 @@ function ManualRegistrationButton({ onPress }: { onPress: () => void }) {
 
 export function AdminHomePage() {
 	const router = useRouter();
+	const { data: partnershipsData, isError: isPartnershipsError } =
+		useAdminPartnerships();
+	const partnerships = partnershipsData?.content.map(toPartnership) ?? [];
+
+	const renderPartnershipSection = () => {
+		if (isPartnershipsError) {
+			return (
+				<EmptyState
+					title="목록을 불러오지 못했어요"
+					description={"잠시 후 다시 시도해주세요"}
+				/>
+			);
+		}
+		if (partnerships.length === 0) {
+			return (
+				<EmptyState
+					title="진행 중인 제휴가 없어요"
+					description={"제휴업체가 추가되면\n여기서 확인할 수 있어요!"}
+				/>
+			);
+		}
+		return (
+			<PartnershipListWidget
+				partnerships={partnerships}
+				maxItems={3}
+				onViewAll={() =>
+					router.push("/(protected)/admin/admin-partnership-list")
+				}
+				onPressCard={(id) =>
+					router.push(`/(protected)/partnership-contract/${id}`)
+				}
+			/>
+		);
+	};
 
 	return (
 		<PageLayout
@@ -79,29 +111,15 @@ export function AdminHomePage() {
 			className="flex-1 bg-neutral"
 			contentContainerClassName="px-6 pb-6"
 		>
-			{/* Header */}
 			<AdminHeaderSection onNotificationPress={noop} />
 
-			{/* Title */}
-			<PageTitle title={MOCK_ADMIN_PAGE_INFO.title} />
+			<PageTitle title="숭실대학교 총학생회" />
 
-			{/* Content container */}
 			<View className="gap-5">
-				{/* Partnership list widget */}
-				<PartnershipListWidget
-					partnerships={MOCK_PARTNERSHIPS}
-					onViewAll={() =>
-						router.push("/(protected)/admin/admin-partnership-list")
-					}
-					onPressCard={(id) =>
-						router.push(`/(protected)/partnership-contract/${id}`)
-					}
-				/>
+				{renderPartnershipSection()}
 
-				{/* Recommendation section */}
 				<RecommendationSection />
 
-				{/* Manual registration button */}
 				<ManualRegistrationButton
 					onPress={() => router.push("/(protected)/partnership-proposal")}
 				/>

--- a/src/pages/partner/home/ui/PartnerHomePage.tsx
+++ b/src/pages/partner/home/ui/PartnerHomePage.tsx
@@ -1,21 +1,62 @@
 import { useRouter } from "expo-router";
 import { View } from "react-native";
 import {
-	MOCK_PARTNER_AFFILIATION_SUMMARIES,
-	MOCK_PARTNERSHIPS,
+	toPartnerAffiliationSummary,
+	toPartnership,
+	usePartnerAdminRecommend,
+	usePartnerPartnerships,
 } from "@/entities/partnership";
 import { AppHeader } from "@/shared/ui/app-header";
+import { EmptyState } from "@/shared/ui/empty-state";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
 import { PageTitle } from "@/shared/ui/page-title";
 import { PartnershipListWidget } from "@/widgets/partnership-list";
 import { PartnershipRecommendationWidget } from "@/widgets/partnership-recommendation";
-import { MOCK_PARTNER_PAGE_INFO } from "../model/mockPartnerPageInfo";
 
-// No-op for stable callback reference
 const noop = () => {};
 
 export function PartnerHomePage() {
 	const router = useRouter();
+
+	const { data: partnershipsData, isError: isPartnershipsError } =
+		usePartnerPartnerships();
+	const partnerships = partnershipsData?.content.map(toPartnership) ?? [];
+
+	const renderPartnershipSection = () => {
+		if (isPartnershipsError) {
+			return (
+				<EmptyState
+					title="목록을 불러오지 못했어요"
+					description={"잠시 후 다시 시도해주세요"}
+				/>
+			);
+		}
+		if (partnerships.length === 0) {
+			return (
+				<EmptyState
+					title="진행 중인 제휴가 없어요"
+					description={"제휴업체가 추가되면\n여기서 확인할 수 있어요!"}
+				/>
+			);
+		}
+		return (
+			<PartnershipListWidget
+				partnerships={partnerships}
+				title="제휴단체 목록"
+				maxItems={3}
+				onViewAll={() =>
+					router.push("/(protected)/partner/partner-partnership-list")
+				}
+				onPressCard={(id) =>
+					router.push(`/(protected)/partnership-contract/${id}`)
+				}
+			/>
+		);
+	};
+
+	const { data: recommendData } = usePartnerAdminRecommend();
+	const summaries =
+		recommendData?.admins.map(toPartnerAffiliationSummary) ?? [];
 
 	return (
 		<PageLayout
@@ -25,31 +66,19 @@ export function PartnerHomePage() {
 			className="flex-1 bg-neutral"
 			contentContainerClassName="px-6 pb-6"
 		>
-			{/* Header */}
 			<AppHeader onNotificationPress={noop} />
 
-			{/* Store name title */}
-			<PageTitle title={MOCK_PARTNER_PAGE_INFO.title} />
+			<PageTitle title="역전할머니맥주" />
 
-			{/* Content sections */}
 			<View className="gap-5">
-				{/* Partnership list widget with gray variant */}
-				<PartnershipListWidget
-					partnerships={MOCK_PARTNERSHIPS}
-					title="제휴단체 목록"
-					onViewAll={() =>
-						router.push("/(protected)/partner/partner-partnership-list")
-					}
-					onPressCard={(id) =>
-						router.push(`/(protected)/partnership-contract/${id}`)
-					}
-				/>
+				{renderPartnershipSection()}
 
-				{/* Recommendation widget with 2 cards */}
-				<PartnershipRecommendationWidget
-					summaries={MOCK_PARTNER_AFFILIATION_SUMMARIES}
-					onContactPress={noop}
-				/>
+				{summaries.length > 0 && (
+					<PartnershipRecommendationWidget
+						summaries={summaries}
+						onContactPress={noop}
+					/>
+				)}
 			</View>
 		</PageLayout>
 	);

--- a/src/pages/partner/partner-partnership-list/ui/PartnershipListPage.tsx
+++ b/src/pages/partner/partner-partnership-list/ui/PartnershipListPage.tsx
@@ -1,8 +1,12 @@
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import { MOCK_PARTNERSHIPS } from "@/entities/partnership";
-import { MOCK_PARTNERSHIP_CONTRACTS } from "@/entities/partnership/model/mockPartnershipContracts";
+import {
+	toPartnership,
+	toPartnershipContract,
+	usePartnerPartnerships,
+	usePartnershipDetail,
+} from "@/entities/partnership";
 import { PartnershipContractModal } from "@/features/partnership-contract";
 import { BackArrowIcon, InfoFillIcon } from "@/shared/assets/icons";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
@@ -47,8 +51,13 @@ export function PartnershipListPage() {
 		null,
 	);
 
-	const selectedContract =
-		MOCK_PARTNERSHIP_CONTRACTS.find((c) => c.id === selectedContractId) ?? null;
+	const { data: partnershipsData } = usePartnerPartnerships();
+	const partnerships = partnershipsData?.content.map(toPartnership) ?? [];
+
+	const { data: detailData } = usePartnershipDetail(selectedContractId);
+	const selectedContract = detailData
+		? toPartnershipContract(detailData)
+		: null;
 
 	return (
 		<>
@@ -61,9 +70,9 @@ export function PartnershipListPage() {
 			>
 				<Header onBack={() => router.back()} />
 				<InfoBox />
-				<CountSection count={MOCK_PARTNERSHIPS.length} />
+				<CountSection count={partnerships.length} />
 				<PartnershipListContent
-					data={MOCK_PARTNERSHIPS}
+					data={partnerships}
 					onPressCard={(id) => setSelectedContractId(id)}
 				/>
 			</PageLayout>

--- a/src/pages/partnership-contract/ui/PartnershipContractPage.tsx
+++ b/src/pages/partnership-contract/ui/PartnershipContractPage.tsx
@@ -1,5 +1,8 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { MOCK_PARTNERSHIP_CONTRACTS } from "@/entities/partnership/model/mockPartnershipContracts";
+import {
+	toPartnershipContract,
+	usePartnershipDetail,
+} from "@/entities/partnership";
 import { PartnershipContractContent } from "@/features/partnership-contract";
 import { EmptyState } from "@/shared/ui/empty-state";
 
@@ -7,9 +10,13 @@ export function PartnershipContractPage() {
 	const { id } = useLocalSearchParams<{ id: string }>();
 	const router = useRouter();
 
-	const contract = MOCK_PARTNERSHIP_CONTRACTS.find((c) => c.id === id) ?? null;
+	const { data, isLoading } = usePartnershipDetail(id ?? null);
 
-	if (!contract) {
+	if (isLoading) {
+		return null;
+	}
+
+	if (!data) {
 		return (
 			<EmptyState
 				title="계약서를 찾을 수 없습니다"
@@ -17,6 +24,8 @@ export function PartnershipContractPage() {
 			/>
 		);
 	}
+
+	const contract = toPartnershipContract(data);
 
 	return (
 		<PartnershipContractContent

--- a/src/shared/api/mocks/handlers/admin.handlers.ts
+++ b/src/shared/api/mocks/handlers/admin.handlers.ts
@@ -1,0 +1,23 @@
+import type MockAdapter from "axios-mock-adapter";
+import type {
+	AdminRecommendResponseDTO,
+	BaseResponse,
+} from "@/entities/partnership";
+
+const mockAdminPartnerRecommend: AdminRecommendResponseDTO = {
+	partnerId: 1,
+	partnerName: "역전할머니맥주 숭실대점",
+	partnerAddress: "서울 동작구 사당로 36-1",
+	partnerDetailAddress: "서정캐슬",
+	partnerUrl: "https://kko.kakao.com/mock-partner-url",
+	partnerPhone: "02-123-4567",
+};
+
+export function registerAdminHandlers(mock: MockAdapter) {
+	mock.onGet("/admin/partner-recommend").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "OK",
+		result: mockAdminPartnerRecommend,
+	} satisfies BaseResponse<AdminRecommendResponseDTO>);
+}

--- a/src/shared/api/mocks/handlers/index.ts
+++ b/src/shared/api/mocks/handlers/index.ts
@@ -1,6 +1,12 @@
 import type MockAdapter from "axios-mock-adapter";
+import { registerAdminHandlers } from "./admin.handlers";
 import { registerExampleHandlers } from "./example.handlers";
+import { registerPartnerHandlers } from "./partner.handlers";
+import { registerPartnershipHandlers } from "./partnership.handlers";
 
 export function registerHandlers(mock: MockAdapter) {
 	registerExampleHandlers(mock);
+	registerAdminHandlers(mock);
+	registerPartnerHandlers(mock);
+	registerPartnershipHandlers(mock);
 }

--- a/src/shared/api/mocks/handlers/partner.handlers.ts
+++ b/src/shared/api/mocks/handlers/partner.handlers.ts
@@ -1,0 +1,35 @@
+import type MockAdapter from "axios-mock-adapter";
+import type {
+	BaseResponse,
+	PartnerRecommendResponseDTO,
+} from "@/entities/partnership";
+
+const mockPartnerAdminRecommend: PartnerRecommendResponseDTO = {
+	admins: [
+		{
+			adminId: 1,
+			adminName: "숭실대학교\n경영학부 학생회",
+			adminAddress: "서울 동작구 상도로 369",
+			adminDetailAddress: "숭실대학교 학생회관 101호",
+			adminUrl: "https://kko.kakao.com/mock-admin-1",
+			adminPhone: "02-820-0114",
+		},
+		{
+			adminId: 2,
+			adminName: "숭실대학교\n스포츠학부 학생회",
+			adminAddress: "서울 동작구 상도로 369",
+			adminDetailAddress: "숭실대학교 학생회관 102호",
+			adminUrl: "https://kko.kakao.com/mock-admin-2",
+			adminPhone: "02-820-0115",
+		},
+	],
+};
+
+export function registerPartnerHandlers(mock: MockAdapter) {
+	mock.onGet("/partner/admin-recommend").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "OK",
+		result: mockPartnerAdminRecommend,
+	} satisfies BaseResponse<PartnerRecommendResponseDTO>);
+}

--- a/src/shared/api/mocks/handlers/partnership.handlers.ts
+++ b/src/shared/api/mocks/handlers/partnership.handlers.ts
@@ -1,0 +1,285 @@
+import type MockAdapter from "axios-mock-adapter";
+import type {
+	BaseResponse,
+	PagedResponse,
+	PartnershipDetailResponseDTO,
+	WritePartnershipResponseDTO,
+} from "@/entities/partnership";
+
+const mockPartnerships: WritePartnershipResponseDTO[] = [
+	{
+		partnershipId: 1,
+		storeName: "역전할머니맥주 숭실대점",
+		adminName: "숭실대학교 총학생회",
+		partnershipPeriodStart: "2025-03-15",
+		partnershipPeriodEnd: "2025-06-15",
+		adminId: 1,
+		partnerId: 1,
+		storeId: 1,
+		isActivated: "ACTIVE",
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "HEADCOUNT",
+				anotherType: false,
+				people: 4,
+				category: "음료",
+				goods: [
+					{ goodsId: 1, goodsName: "캔 음료" },
+					{ goodsId: 2, goodsName: "생맥주 1잔" },
+				],
+			},
+		],
+	},
+	{
+		partnershipId: 2,
+		storeName: "떠그릭 동작점",
+		adminName: "숭실대학교 총학생회",
+		partnershipPeriodStart: "2025-02-01",
+		partnershipPeriodEnd: "2025-08-31",
+		adminId: 1,
+		partnerId: 2,
+		storeId: 2,
+		isActivated: "ACTIVE",
+		options: [
+			{
+				optionType: "DISCOUNT",
+				criterionType: "PRICE",
+				anotherType: false,
+				cost: 10000,
+				discountRate: 10,
+				goods: [{ goodsId: 3, goodsName: "전체 메뉴" }],
+			},
+		],
+	},
+	{
+		partnershipId: 3,
+		storeName: "카페 숭실",
+		adminName: "숭실대학교 총학생회",
+		partnershipPeriodStart: "2025-03-01",
+		partnershipPeriodEnd: "2025-09-30",
+		adminId: 1,
+		partnerId: 3,
+		storeId: 3,
+		isActivated: "ACTIVE",
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "PRICE",
+				anotherType: true,
+				note: "아메리카노 1000원 할인",
+				goods: [{ goodsId: 4, goodsName: "아메리카노" }],
+			},
+		],
+	},
+	{
+		partnershipId: 4,
+		storeName: "피자스쿨 숭실대점",
+		adminName: "숭실대학교 경영학부 학생회",
+		partnershipPeriodStart: "2024-09-01",
+		partnershipPeriodEnd: "2025-02-28",
+		adminId: 2,
+		partnerId: 4,
+		storeId: 4,
+		isActivated: "INACTIVE",
+		options: [
+			{
+				optionType: "DISCOUNT",
+				criterionType: "HEADCOUNT",
+				anotherType: false,
+				people: 2,
+				discountRate: 15,
+				cost: 20000,
+				goods: [{ goodsId: 5, goodsName: "피자 전 메뉴" }],
+			},
+		],
+	},
+	{
+		partnershipId: 5,
+		storeName: "GS25 숭실대점",
+		adminName: "숭실대학교 스포츠학부 학생회",
+		partnershipPeriodStart: "2025-01-01",
+		partnershipPeriodEnd: "2025-12-31",
+		adminId: 3,
+		partnerId: 5,
+		storeId: 5,
+		isActivated: "SUSPEND",
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "PRICE",
+				anotherType: false,
+				cost: 5000,
+				category: "간식",
+				goods: [
+					{ goodsId: 6, goodsName: "삼각김밥" },
+					{ goodsId: 7, goodsName: "컵라면" },
+				],
+			},
+		],
+	},
+];
+
+const mockPartnershipDetails: Record<string, PartnershipDetailResponseDTO> = {
+	"1": {
+		partnershipId: 1,
+		updatedAt: "2025-03-01T00:00:00",
+		partnershipPeriodStart: "2025-03-15",
+		partnershipPeriodEnd: "2025-06-15",
+		adminId: 1,
+		partnerId: 1,
+		storeId: 1,
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "HEADCOUNT",
+				anotherType: false,
+				people: 4,
+				category: "음료",
+				goods: [
+					{ goodsId: 1, goodsName: "캔 음료" },
+					{ goodsId: 2, goodsName: "생맥주 1잔" },
+				],
+			},
+			{
+				optionType: "SERVICE",
+				criterionType: "HEADCOUNT",
+				anotherType: false,
+				people: 6,
+				category: "안주",
+				goods: [{ goodsId: 3, goodsName: "안주 1개" }],
+			},
+		],
+	},
+	"2": {
+		partnershipId: 2,
+		updatedAt: "2025-01-25T00:00:00",
+		partnershipPeriodStart: "2025-02-01",
+		partnershipPeriodEnd: "2025-08-31",
+		adminId: 1,
+		partnerId: 2,
+		storeId: 2,
+		options: [
+			{
+				optionType: "DISCOUNT",
+				criterionType: "PRICE",
+				anotherType: false,
+				cost: 10000,
+				discountRate: 10,
+				goods: [{ goodsId: 4, goodsName: "전체 메뉴" }],
+			},
+		],
+	},
+	"3": {
+		partnershipId: 3,
+		updatedAt: "2025-02-20T00:00:00",
+		partnershipPeriodStart: "2025-03-01",
+		partnershipPeriodEnd: "2025-09-30",
+		adminId: 1,
+		partnerId: 3,
+		storeId: 3,
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "PRICE",
+				anotherType: true,
+				note: "아메리카노 1000원 할인",
+				goods: [{ goodsId: 5, goodsName: "아메리카노" }],
+			},
+		],
+	},
+	"4": {
+		partnershipId: 4,
+		updatedAt: "2024-08-20T00:00:00",
+		partnershipPeriodStart: "2024-09-01",
+		partnershipPeriodEnd: "2025-02-28",
+		adminId: 2,
+		partnerId: 4,
+		storeId: 4,
+		options: [
+			{
+				optionType: "DISCOUNT",
+				criterionType: "HEADCOUNT",
+				anotherType: false,
+				people: 2,
+				discountRate: 15,
+				cost: 20000,
+				goods: [{ goodsId: 6, goodsName: "피자 전 메뉴" }],
+			},
+		],
+	},
+	"5": {
+		partnershipId: 5,
+		updatedAt: "2024-12-15T00:00:00",
+		partnershipPeriodStart: "2025-01-01",
+		partnershipPeriodEnd: "2025-12-31",
+		adminId: 3,
+		partnerId: 5,
+		storeId: 5,
+		options: [
+			{
+				optionType: "SERVICE",
+				criterionType: "PRICE",
+				anotherType: false,
+				cost: 5000,
+				category: "간식",
+				goods: [
+					{ goodsId: 7, goodsName: "삼각김밥" },
+					{ goodsId: 8, goodsName: "컵라면" },
+				],
+			},
+		],
+	},
+};
+
+const pagedResponse = <T>(content: T[]): PagedResponse<T> => ({
+	content,
+	totalPages: 1,
+	totalElements: content.length,
+	size: content.length,
+	number: 0,
+	first: true,
+	last: true,
+	empty: content.length === 0,
+});
+
+export function registerPartnershipHandlers(mock: MockAdapter) {
+	mock.onGet("/partnership/admin").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "OK",
+		result: pagedResponse(mockPartnerships),
+	} satisfies BaseResponse<PagedResponse<WritePartnershipResponseDTO>>);
+
+	mock.onGet("/partnership/partner").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "OK",
+		result: pagedResponse(mockPartnerships),
+	} satisfies BaseResponse<PagedResponse<WritePartnershipResponseDTO>>);
+
+	mock.onGet(/^\/partnership\/(\d+)$/).reply((config) => {
+		const id = config.url?.split("/").pop() ?? "";
+		const detail = mockPartnershipDetails[id];
+		if (!detail) {
+			return [
+				404,
+				{
+					isSuccess: false,
+					code: "NOT_FOUND",
+					message: "제휴를 찾을 수 없습니다.",
+					result: null,
+				},
+			];
+		}
+		return [
+			200,
+			{
+				isSuccess: true,
+				code: "COMMON200",
+				message: "OK",
+				result: detail,
+			} satisfies BaseResponse<PartnershipDetailResponseDTO>,
+		];
+	});
+}

--- a/src/widgets/partnership-list/ui/PartnershipListWidget.tsx
+++ b/src/widgets/partnership-list/ui/PartnershipListWidget.tsx
@@ -6,6 +6,7 @@ interface PartnershipListWidgetProps {
 	partnerships: Partnership[];
 	title?: string;
 	variant?: "white" | "gray";
+	maxItems?: number;
 	onViewAll?: () => void;
 	onPressCard?: (id: string) => void;
 }
@@ -15,12 +16,14 @@ export const PartnershipListWidget = memo(
 		partnerships,
 		title = "제휴단체 목록",
 		variant = "white",
+		maxItems,
 		onViewAll,
 		onPressCard,
 	}: PartnershipListWidgetProps) => {
+		const displayed = maxItems ? partnerships.slice(0, maxItems) : partnerships;
+
 		return (
 			<View className="gap-2">
-				{/* Header */}
 				<View className="flex-row items-center justify-between">
 					<Text className="text-lg font-medium text-content-primary">
 						{title}
@@ -32,9 +35,8 @@ export const PartnershipListWidget = memo(
 					</Pressable>
 				</View>
 
-				{/* Cards list */}
 				<View className="gap-5">
-					{partnerships.map((partnership) => (
+					{displayed.map((partnership) => (
 						<Pressable
 							key={partnership.id}
 							onPress={() => onPressCard?.(partnership.id)}


### PR DESCRIPTION
## 📝 요약
- 파트너십 도메인 API 타입, 어댑터, React Query 훅 구현
- axios-mock-adapter 핸들러로 admin/partner/partnership 엔드포인트 목데이터 연결
- 메인 화면 제휴 목록에 최대 3개 제한 및 에러/빈 상태 UI 추가

## ⚙️ 작업 내용
- `entities/partnership`에 API DTO 타입, 어댑터 함수, React Query 훅 구현
- mock 핸들러 3종 구현 (admin/partner/partnership), ACTIVE/INACTIVE/SUSPEND 상태 포함한 목데이터 세팅
- `PartnershipListWidget`을 순수 display 컴포넌트로 설계 (fetch 상태 무관)
- 페이지 레벨(Early Return 패턴)에서 isError / empty 분기 처리
- `maxItems` prop으로 메인 화면 최대 3개 노출 제한
- ADR 문서 2건 작성 (비동기 상태 처리 패턴, Widget 설계 원칙)

## 🔗 관련 이슈
- Closes #106

## ✅ 체크리스트
- [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
- [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
- [ ] 변경 사항에 대한 테스트를 마쳤습니다.
- [x] 불필요한 로그(console.log)를 제거하였습니다.

## 💬 리뷰어에게
- Widget 설계 원칙(ADR-002)에 따라 `PartnershipListWidget`에서 `isError` prop을 제거하고 페이지에서 Early Return 패턴으로 처리했습니다. 관련 근거는 `docs/decisions/`에 정리했어요.
- mock 데이터는 ACTIVE/INACTIVE/SUSPEND 3가지 상태를 모두 포함하고 있습니다.