### PR TITLE
[FEAT/#116] 학생 대시보드 API 연동

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,63 @@
+# taegeon2 작업 체크리스트
+
+담당자: taegeon2  
+API 명세서: `openapi/oepnapi.json`
+
+---
+
+## 작업 현황
+
+### 신고 (Report)
+
+- [ ] 공통 신고 다이얼로그 API 연동 (`POST /reports`, `POST /reports/students`)
+
+### 학생 대시보드
+
+- [x] 건의함 작성 API 연동 (`POST /suggestion`, `GET /suggestion/admin`)
+- [x] 이용한 제휴 내역 API 연동 (`GET /students/partnerships/{year}/{month}`)
+- [ ] 내 리뷰 목록 API 연동 (`GET /reviews/student`)
+
+### 관리자 대시보드
+
+- [ ] 통계 카드 API 연동 (`GET /admin/dashBoard`, `/countUser`, `/new`, `/top`)
+- [ ] 이용 현황 목록 API 연동 (`GET /admin/dashBoard/usage`)
+- [ ] 제휴 건의함 목록 API 연동 (`GET /suggestion/list`) // 관리자가 받은 건의 목록
+
+### 제휴업체 대시보드
+
+- [ ] 통계 UI 구현 (미착수) -> 기획 보고 수정 예정
+- [ ] 통계 API 연동 (`GET /store/ranking/weekly`)
+- [ ] 고객 리뷰 목록 API 연동 (`GET /reviews/store/{storeId}`, `GET /reviews/average`)
+
+### 맵 (최후반 — 네이티브 전환 후 진행)
+
+- [ ] 주변 가게 목록 API 연동 (`GET /map/nearby`)
+- [ ] 가게 검색 API 연동 (`GET /map/search`, `GET /map/place`)
+
+> 맵은 현재 WebView 기반 임시 구현. 네이티브 전환 시 팀 전체 EAS dev client 전환 필요 (팀 회의 필요).
+
+---
+
+## 완료 항목
+
+### 학생
+
+- [x] 제휴 건의함 UI
+- [x] 이용한 제휴 내역 UI
+- [x] 내 리뷰 목록 UI
+
+### 관리자
+
+- [x] 대시보드 통계 UI
+- [x] 제휴 건의함 UI
+
+### 제휴업체
+
+- [x] 고객 리뷰 목록 UI
+
+### 공통
+
+- [x] 신고 다이얼로그 UI
+- [x] 맵 탭 UI (학생/관리자/제휴업체)
+- [x] 가게 검색 UI
+- [x] 카카오맵 WebView 연동 // 네이티브로 수정 예정

--- a/src/entities/partnership/api/getMyPartnerships.ts
+++ b/src/entities/partnership/api/getMyPartnerships.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import { toPartnershipBenefit } from "../lib/adapters";
+import type { BaseResponse, MyPartnershipDto } from "../model/api-types";
+import type { Benefit } from "../model/types";
+
+interface MyPartnerships {
+	serviceCount: number;
+	details: Benefit[];
+}
+
+async function fetchMyPartnerships(
+	year: number,
+	month: number,
+): Promise<MyPartnerships> {
+	if (__DEV__) console.log(`[useMyPartnerships] 요청: ${year}년 ${month}월`);
+	const res = await apiInstance.get<BaseResponse<MyPartnershipDto>>(
+		`/students/partnerships/${year}/${month}`,
+	);
+	const { serviceCount, details } = res.data.result;
+	if (__DEV__)
+		console.log(`[useMyPartnerships] 응답: 총 ${serviceCount}건`, details);
+	return {
+		serviceCount,
+		details: details.map(toPartnershipBenefit),
+	};
+}
+
+export function useMyPartnerships(year: number, month: number) {
+	return useQuery({
+		queryKey: ["partnerships", "my", year, month],
+		queryFn: () => fetchMyPartnerships(year, month),
+	});
+}

--- a/src/entities/partnership/index.ts
+++ b/src/entities/partnership/index.ts
@@ -1,7 +1,9 @@
+export { useMyPartnerships } from "./api/getMyPartnerships";
 export { MOCK_ADMIN_AFFILIATION_SUMMARY } from "./model/mockAdminAffiliationSummary";
 export { MOCK_PARTNER_AFFILIATION_SUMMARIES } from "./model/mockPartnerAffiliationSummaries";
 export { MOCK_PARTNERSHIPS } from "./model/mockPartnerships";
 export type {
+	Benefit,
 	BenefitCriteria,
 	BenefitItem,
 	DiscountBenefitItem,

--- a/src/entities/partnership/lib/adapters.ts
+++ b/src/entities/partnership/lib/adapters.ts
@@ -1,0 +1,15 @@
+import type { UsageDetailDto } from "../model/api-types";
+import type { Benefit } from "../model/types";
+
+export function toPartnershipBenefit(dto: UsageDetailDto): Benefit {
+	const [date, timePart] = dto.usedAt.split("T");
+	const time = timePart?.substring(0, 5) ?? "";
+
+	return {
+		id: dto.partnershipUsageId.toString(),
+		storeName: dto.storeName,
+		date,
+		time,
+		description: dto.benefitDescription,
+	};
+}

--- a/src/entities/partnership/model/api-types.ts
+++ b/src/entities/partnership/model/api-types.ts
@@ -1,0 +1,23 @@
+export interface BaseResponse<T> {
+	isSuccess: boolean;
+	code: string;
+	message: string;
+	result: T;
+}
+
+/** GET /students/partnerships/{year}/{month} */
+export interface UsageDetailDto {
+	partnershipUsageId: number;
+	storeName: string;
+	storeId: number;
+	partnerId: number;
+	adminName: string;
+	usedAt: string;
+	benefitDescription: string;
+	isReviewed: boolean;
+}
+
+export interface MyPartnershipDto {
+	serviceCount: number;
+	details: UsageDetailDto[];
+}

--- a/src/entities/partnership/model/types.ts
+++ b/src/entities/partnership/model/types.ts
@@ -1,3 +1,11 @@
+export interface Benefit {
+	id: string;
+	storeName: string;
+	date: string;
+	time: string;
+	description: string;
+}
+
 export const SERVICE_TYPES = ["서비스 제공", "할인 혜택", "기타 혜택"] as const;
 export type ServiceType = (typeof SERVICE_TYPES)[number];
 export type BenefitCriteria = "금액" | "인원수";

--- a/src/entities/suggestion/api/getSuggestionAdmins.ts
+++ b/src/entities/suggestion/api/getSuggestionAdmins.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiInstance } from "@/shared/api/instance";
+import type { SelectItem } from "@/shared/ui/select";
+import { toSuggestionTargetItems } from "../lib/adapters";
+import type { BaseResponse, GetSuggestionAdminsDto } from "../model/api-types";
+
+async function fetchSuggestionAdmins(): Promise<SelectItem[]> {
+	const res =
+		await apiInstance.get<BaseResponse<GetSuggestionAdminsDto>>(
+			"/suggestion/admin",
+		);
+	return toSuggestionTargetItems(res.data.result);
+}
+
+export function useSuggestionAdmins() {
+	return useQuery({
+		queryKey: ["suggestion", "admins"],
+		queryFn: fetchSuggestionAdmins,
+	});
+}

--- a/src/entities/suggestion/index.ts
+++ b/src/entities/suggestion/index.ts
@@ -1,0 +1,7 @@
+export { useSuggestionAdmins } from "./api/getSuggestionAdmins";
+export type {
+	BaseResponse,
+	GetSuggestionAdminsDto,
+	WriteSuggestionRequestDto,
+	WriteSuggestionResponseDto,
+} from "./model/api-types";

--- a/src/entities/suggestion/lib/adapters.ts
+++ b/src/entities/suggestion/lib/adapters.ts
@@ -1,0 +1,12 @@
+import type { SelectItem } from "@/shared/ui/select";
+import type { GetSuggestionAdminsDto } from "../model/api-types";
+
+export function toSuggestionTargetItems(
+	dto: GetSuggestionAdminsDto,
+): SelectItem[] {
+	return [
+		{ label: dto.adminName, value: String(dto.adminId) },
+		{ label: dto.departName, value: String(dto.departId) },
+		{ label: dto.majorName, value: String(dto.majorId) },
+	];
+}

--- a/src/entities/suggestion/model/api-types.ts
+++ b/src/entities/suggestion/model/api-types.ts
@@ -1,0 +1,32 @@
+export interface BaseResponse<T> {
+	isSuccess: boolean;
+	code: string;
+	message: string;
+	result: T;
+}
+
+/** GET /suggestion/admin */
+export interface GetSuggestionAdminsDto {
+	adminId: number;
+	adminName: string;
+	departId: number;
+	departName: string;
+	majorId: number;
+	majorName: string;
+}
+
+/** POST /suggestion — 요청 */
+export interface WriteSuggestionRequestDto {
+	adminId: number;
+	storeName: string;
+	benefit: string;
+}
+
+/** POST /suggestion — 응답 */
+export interface WriteSuggestionResponseDto {
+	suggestionId: number;
+	userId: number;
+	adminId: number;
+	storeName: string;
+	suggestionBenefit: string;
+}

--- a/src/pages/student/suggestion-form/api/postSuggestion.ts
+++ b/src/pages/student/suggestion-form/api/postSuggestion.ts
@@ -1,10 +1,29 @@
+import type {
+	BaseResponse,
+	WriteSuggestionRequestDto,
+	WriteSuggestionResponseDto,
+} from "@/entities/suggestion";
+import { apiInstance } from "@/shared/api/instance";
+
 export type PostSuggestionPayload = {
 	target: string;
 	storeName: string;
 	desiredBenefit: string;
 };
 
-// TODO: 백엔드 API 연동 시 실제 엔드포인트로 교체
 export async function postSuggestion(
-	_payload: PostSuggestionPayload,
-): Promise<void> {}
+	payload: PostSuggestionPayload,
+): Promise<WriteSuggestionResponseDto> {
+	const body: WriteSuggestionRequestDto = {
+		adminId: Number(payload.target),
+		storeName: payload.storeName,
+		benefit: payload.desiredBenefit,
+	};
+	if (__DEV__) console.log("[postSuggestion] 요청:", body);
+	const res = await apiInstance.post<BaseResponse<WriteSuggestionResponseDto>>(
+		"/suggestion",
+		body,
+	);
+	if (__DEV__) console.log("[postSuggestion] 응답:", res.data.result);
+	return res.data.result;
+}

--- a/src/pages/student/suggestion-form/ui/SuggestionForm.tsx
+++ b/src/pages/student/suggestion-form/ui/SuggestionForm.tsx
@@ -2,14 +2,16 @@ import { Ionicons } from "@expo/vector-icons";
 import { Controller } from "react-hook-form";
 import { Text, View } from "react-native";
 
+import { useSuggestionAdmins } from "@/entities/suggestion";
 import { colorTokens } from "@/shared/styles/tokens";
 import { MediumButton } from "@/shared/ui/buttons/SubmitButton";
 import { FormField } from "@/shared/ui/FormField";
 import { Select } from "@/shared/ui/select";
-import { SUGGESTION_TARGET_ITEMS, useSuggestionForm } from "../model";
+import { useSuggestionForm } from "../model";
 
 export function SuggestionForm() {
 	const { control, onSubmit, isValid } = useSuggestionForm();
+	const { data: targetItems = [] } = useSuggestionAdmins();
 
 	return (
 		<View className="flex-1 justify-between">
@@ -28,7 +30,7 @@ export function SuggestionForm() {
 							</View>
 							<View className="flex-1">
 								<Select
-									items={SUGGESTION_TARGET_ITEMS}
+									items={targetItems}
 									value={field.value || null}
 									onChange={(val) => field.onChange(val ?? "")}
 									placeholder="건의대상 선택"

--- a/src/pages/student/suggestion/model/types.ts
+++ b/src/pages/student/suggestion/model/types.ts
@@ -1,10 +1,4 @@
-export interface Benefit {
-	id: string;
-	storeName: string;
-	date: string;
-	time: string;
-	description: string;
-}
+export type { Benefit } from "@/entities/partnership";
 
 // YYYY-MM-DD 형식의 날짜 문자열에서 월(1~12)을 추출한다
 export function getMonthFromDateStr(dateStr: string): number {

--- a/src/pages/student/suggestion/model/useMonthNavigator.ts
+++ b/src/pages/student/suggestion/model/useMonthNavigator.ts
@@ -1,8 +1,25 @@
 import { useState } from "react";
 
-export function useMonthNavigator(initialMonth: number) {
-	const [month, setMonth] = useState(initialMonth);
-	const handlePrev = () => setMonth((m) => (m === 1 ? 12 : m - 1));
-	const handleNext = () => setMonth((m) => (m === 12 ? 1 : m + 1));
-	return { month, setMonth, handlePrev, handleNext };
+interface MonthNavigatorState {
+	year: number;
+	month: number;
+}
+
+export function useMonthNavigator(initialYear: number, initialMonth: number) {
+	const [state, setState] = useState<MonthNavigatorState>({
+		year: initialYear,
+		month: initialMonth,
+	});
+
+	const handlePrev = () =>
+		setState(({ year, month }) =>
+			month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 },
+		);
+
+	const handleNext = () =>
+		setState(({ year, month }) =>
+			month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 },
+		);
+
+	return { year: state.year, month: state.month, handlePrev, handleNext };
 }

--- a/src/pages/student/suggestion/ui/BenefitAllPage.tsx
+++ b/src/pages/student/suggestion/ui/BenefitAllPage.tsx
@@ -14,10 +14,15 @@ import { MonthNavigator } from "./MonthNavigator";
 
 export function BenefitAllPage() {
 	const { month: monthParam } = useLocalSearchParams<{ month: string }>();
+	const now = new Date();
+	const initialYear = now.getFullYear();
 	const initialMonth = monthParam
 		? parseInt(monthParam, 10)
-		: new Date().getMonth() + 1;
-	const { month, handlePrev, handleNext } = useMonthNavigator(initialMonth);
+		: now.getMonth() + 1;
+	const { month, handlePrev, handleNext } = useMonthNavigator(
+		initialYear,
+		initialMonth,
+	);
 	const benefits = useBenefitsStore((s) => s.benefits);
 
 	const benefitsForMonth = benefits.filter(

--- a/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
+++ b/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
@@ -18,9 +18,10 @@ import { SuggestionSection } from "./SuggestionSection";
 const COLLAPSED_LIMIT = 3;
 
 export function StudentSuggestionPage() {
-	const year = new Date().getFullYear();
-	const { month, handlePrev, handleNext } = useMonthNavigator(
-		new Date().getMonth() + 1,
+	const now = new Date();
+	const { year, month, handlePrev, handleNext } = useMonthNavigator(
+		now.getFullYear(),
+		now.getMonth() + 1,
 	);
 
 	const { data, isLoading, isError, error } = useMyPartnerships(year, month);

--- a/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
+++ b/src/pages/student/suggestion/ui/StudentSuggestionPage.tsx
@@ -1,9 +1,13 @@
 import { router } from "expo-router";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import {
+	ActivityIndicator,
+	Pressable,
+	ScrollView,
+	Text,
+	View,
+} from "react-native";
+import { useMyPartnerships } from "@/entities/partnership";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
-import { MOCK_BENEFITS } from "../model/mockBenefits";
-import { getMonthFromDateStr } from "../model/types";
-import { useBenefitsStore } from "../model/useBenefitsStore";
 import { useMonthNavigator } from "../model/useMonthNavigator";
 import { BenefitEmptyState } from "./BenefitEmptyState";
 import { BenefitList } from "./BenefitList";
@@ -14,43 +18,26 @@ import { SuggestionSection } from "./SuggestionSection";
 const COLLAPSED_LIMIT = 3;
 
 export function StudentSuggestionPage() {
+	const year = new Date().getFullYear();
 	const { month, handlePrev, handleNext } = useMonthNavigator(
 		new Date().getMonth() + 1,
 	);
-	const { benefits, addBenefit } = useBenefitsStore();
 
-	const benefitsForMonth = benefits.filter(
-		(b) => getMonthFromDateStr(b.date) === month,
-	);
-	const count = benefitsForMonth.length;
-	const displayBenefits = benefitsForMonth.slice(0, COLLAPSED_LIMIT);
+	const { data, isLoading, isError, error } = useMyPartnerships(year, month);
 
-	const handleAddRandom = () => {
-		const random =
-			MOCK_BENEFITS[Math.floor(Math.random() * MOCK_BENEFITS.length)];
-		const dateStr = new Date().toISOString().split("T")[0];
-		addBenefit({ ...random, id: `${random.id}-${Date.now()}`, date: dateStr });
-	};
+	const details = data?.details ?? [];
+	const count = data?.serviceCount ?? 0;
+	const displayBenefits = details.slice(0, COLLAPSED_LIMIT);
 
 	return (
 		<PageLayout contentContainerClassName="flex-1">
 			<ScrollView className="flex-1" contentContainerClassName="flex-grow">
 				<View className="px-screen-m gap-6 pt-10">
-					<View className="flex-row items-center justify-between">
-						<MonthNavigator
-							month={month}
-							onPrev={handlePrev}
-							onNext={handleNext}
-						/>
-						<Pressable
-							className="bg-neutral px-3 py-1.5 rounded-[8px]"
-							onPress={handleAddRandom}
-						>
-							<Text className="font-medium text-sm text-content-secondary">
-								+ 가게 추가
-							</Text>
-						</Pressable>
-					</View>
+					<MonthNavigator
+						month={month}
+						onPrev={handlePrev}
+						onNext={handleNext}
+					/>
 					<View className="flex-row items-end justify-between">
 						<BenefitSummary month={month} count={count} />
 						{count > COLLAPSED_LIMIT && (
@@ -66,7 +53,15 @@ export function StudentSuggestionPage() {
 						)}
 					</View>
 				</View>
-				{count === 0 ? (
+				{isLoading ? (
+					<View className="flex-1 items-center justify-center">
+						<ActivityIndicator />
+					</View>
+				) : isError ? (
+					<View className="flex-1 items-center justify-center">
+						<Text className="text-danger">{String(error)}</Text>
+					</View>
+				) : count === 0 ? (
 					<View className="flex-1 items-center justify-center">
 						<BenefitEmptyState />
 					</View>

--- a/src/shared/api/mocks/handlers/index.ts
+++ b/src/shared/api/mocks/handlers/index.ts
@@ -1,6 +1,8 @@
 import type MockAdapter from "axios-mock-adapter";
 import { registerExampleHandlers } from "./example.handlers";
+import { registerStudentHandlers } from "./student.handlers";
 
 export function registerHandlers(mock: MockAdapter) {
 	registerExampleHandlers(mock);
+	registerStudentHandlers(mock);
 }

--- a/src/shared/api/mocks/handlers/student.handlers.ts
+++ b/src/shared/api/mocks/handlers/student.handlers.ts
@@ -1,0 +1,71 @@
+import type MockAdapter from "axios-mock-adapter";
+
+export function registerStudentHandlers(mock: MockAdapter) {
+	mock.onGet("/suggestion/admin").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "성공",
+		result: {
+			adminId: 1,
+			adminName: "숭실대학교 총학생회",
+			departId: 2,
+			departName: "IT대학 학생회",
+			majorId: 3,
+			majorName: "컴퓨터학부 학생회",
+		},
+	});
+
+	mock.onPost("/suggestion").reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "성공",
+		result: {
+			suggestionId: 1,
+			userId: 10,
+			adminId: 1,
+			storeName: "스타벅스 숭실대점",
+			suggestionBenefit: "아메리카노 10% 할인",
+		},
+	});
+
+	mock.onGet(/\/students\/partnerships\/\d+\/\d+/).reply(200, {
+		isSuccess: true,
+		code: "COMMON200",
+		message: "성공",
+		result: {
+			serviceCount: 3,
+			details: [
+				{
+					partnershipUsageId: 1,
+					storeName: "인쌩맥주 숭실대점",
+					storeId: 101,
+					partnerId: 201,
+					adminName: "홍길동",
+					usedAt: "2025-05-15T18:36:00",
+					benefitDescription: "음료 한병을 제공받았어요!",
+					isReviewed: false,
+				},
+				{
+					partnershipUsageId: 2,
+					storeName: "스타벅스 숭실대입구점",
+					storeId: 102,
+					partnerId: 202,
+					adminName: "김철수",
+					usedAt: "2025-05-10T14:20:00",
+					benefitDescription: "아메리카노 1잔을 제공받았어요!",
+					isReviewed: true,
+				},
+				{
+					partnershipUsageId: 3,
+					storeName: "맥도날드 숭실대점",
+					storeId: 103,
+					partnerId: 203,
+					adminName: "이영희",
+					usedAt: "2025-05-08T12:00:00",
+					benefitDescription: "맥버거 세트를 제공받았어요!",
+					isReviewed: false,
+				},
+			],
+		},
+	});
+}

--- a/src/shared/ui/kakao-map/KakaoMap.tsx
+++ b/src/shared/ui/kakao-map/KakaoMap.tsx
@@ -158,7 +158,6 @@ function buildMapHtml(
         center: initialPos,
         level: 3
       });
-      createMyLocationOverlay(initialPos);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'MAP_READY' }));
     }
   </script>

--- a/src/widgets/map/model/useUserLocation.ts
+++ b/src/widgets/map/model/useUserLocation.ts
@@ -15,6 +15,7 @@ export function useUserLocation() {
 
 	useFocusEffect(
 		useCallback(() => {
+			let isMounted = true;
 			let positionSub: Location.LocationSubscription | undefined;
 			let headingSub: Location.LocationSubscription | undefined;
 
@@ -30,7 +31,7 @@ export function useUserLocation() {
 				setCenter(userLoc);
 				setMyLocation(userLoc);
 
-				positionSub = await Location.watchPositionAsync(
+				const posSub = await Location.watchPositionAsync(
 					{
 						accuracy: Location.Accuracy.High,
 						timeInterval: 2000,
@@ -39,8 +40,13 @@ export function useUserLocation() {
 					(l) =>
 						setMyLocation({ lat: l.coords.latitude, lng: l.coords.longitude }),
 				);
+				if (!isMounted) {
+					posSub.remove();
+					return;
+				}
+				positionSub = posSub;
 
-				headingSub = await Location.watchHeadingAsync((hdg) => {
+				const hdgSub = await Location.watchHeadingAsync((hdg) => {
 					const rounded = Math.round(hdg.magHeading);
 					if (
 						lastHeadingRef.current === null ||
@@ -50,9 +56,15 @@ export function useUserLocation() {
 						setHeading(rounded);
 					}
 				});
+				if (!isMounted) {
+					hdgSub.remove();
+					return;
+				}
+				headingSub = hdgSub;
 			})();
 
 			return () => {
+				isMounted = false;
 				positionSub?.remove();
 				headingSub?.remove();
 			};

--- a/src/widgets/map/ui/MapLocateButton.tsx
+++ b/src/widgets/map/ui/MapLocateButton.tsx
@@ -22,6 +22,7 @@ export function MapLocateButton({ onPress, disabled }: MapLocateButtonProps) {
 			className="absolute right-card-p flex-row items-center justify-center gap-gutter rounded-full bg-canvas p-gutter"
 			style={{
 				top: insets.top + TOP_OFFSET_BELOW_SEARCH_BAR,
+				opacity: disabled ? 0.5 : 1,
 				...shadows.neutral,
 			}}
 			hitSlop={8}


### PR DESCRIPTION
 ## 📝 요약
  학생 대시보드의 이용한 제휴 내역 조회 및 건의함 작성 API를 연동합니다.

  ## ⚙️ 작업 내용
  - GET /students/partnerships/{year}/{month} 이용한 제휴 내역 연동
  - GET /suggestion/admin 건의 대상 관리자 목록 연동
  - POST /suggestion 건의 작성 연동
  - 개발 환경 목 핸들러 추가 (student.handlers.ts)

  ## 🔗 관련 이슈
  Closes #116

  ## ✅  체크리스트
  - [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
  - [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
  - [x] 변경 사항에 대한 테스트를 마쳤습니다.
  - [ ] 불필요한 로그(console.log)를 제거하였습니다. // 개발 모드에서만 켜놨습니다!

  ## 💬 리뷰어에게
- 저희 작업 리스트 정리용으로 TASKS.md 만들었는데, 이거 활용하는거 어떨지 의견이 궁금합니다.
특히 LLM에게 작업을 시킬 때 컨텍스트 관리하는데 유용하지 않을까 싶어서요..! 불필요하다 생각하시면 제거하겠습니다!



<img width="990" height="452" alt="image" src="https://github.com/user-attachments/assets/8819906e-ee92-4450-b2c7-bdad03456067" />