### PR TITLE
[FEAT/#119] 담당 페이지 API 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,10 @@ app-example
 CLAUDE.md
 CONVENTION.md
 
+# codex
+.codex/
+.codexignore
+
 .omc/
 
 troubles/
-

--- a/TASKS.md
+++ b/TASKS.md
@@ -9,30 +9,30 @@ API 명세서: `openapi/oepnapi.json`
 
 ### 신고 (Report)
 
-- [ ] 공통 신고 다이얼로그 API 연동 (`POST /reports`, `POST /reports/students`)
+- [x] 공통 신고 다이얼로그 API 연동 (`POST /reports`, `POST /reports/students`)
 
 ### 학생 대시보드
 
 - [x] 건의함 작성 API 연동 (`POST /suggestion`, `GET /suggestion/admin`)
 - [x] 이용한 제휴 내역 API 연동 (`GET /students/partnerships/{year}/{month}`)
-- [ ] 내 리뷰 목록 API 연동 (`GET /reviews/student`)
+- [x] 내 리뷰 목록 API 연동 (`GET /reviews/student`)
 
 ### 관리자 대시보드
 
-- [ ] 통계 카드 API 연동 (`GET /admin/dashBoard`, `/countUser`, `/new`, `/top`)
-- [ ] 이용 현황 목록 API 연동 (`GET /admin/dashBoard/usage`)
-- [ ] 제휴 건의함 목록 API 연동 (`GET /suggestion/list`) // 관리자가 받은 건의 목록
+- [x] 통계 카드 API 연동 (`GET /admin/dashBoard`, `/countUser`, `/new`, `/top`)
+- [x] 이용 현황 목록 API 연동 (`GET /admin/dashBoard/usage`)
+- [x] 제휴 건의함 목록 API 연동 (`GET /suggestion/list`) // 관리자가 받은 건의 목록
 
 ### 제휴업체 대시보드
 
-- [ ] 통계 UI 구현 (미착수) -> 기획 보고 수정 예정
-- [ ] 통계 API 연동 (`GET /store/ranking/weekly`)
-- [ ] 고객 리뷰 목록 API 연동 (`GET /reviews/store/{storeId}`, `GET /reviews/average`)
+- [x] 통계 UI 구현
+- [x] 통계 API 연동 (`GET /store/ranking/weekly`)
+- [x] 고객 리뷰 목록 API 연동 (`GET /reviews/partner`, `GET /reviews/store/{storeId}`, `GET /reviews/average`)
 
 ### 맵 (최후반 — 네이티브 전환 후 진행)
 
-- [ ] 주변 가게 목록 API 연동 (`GET /map/nearby`)
-- [ ] 가게 검색 API 연동 (`GET /map/search`, `GET /map/place`)
+- [x] 주변 가게 목록 API 연동 (`GET /map/nearby`)
+- [x] 가게 검색 API 연동 (`GET /map/search`, `GET /map/place`)
 
 > 맵은 현재 WebView 기반 임시 구현. 네이티브 전환 시 팀 전체 EAS dev client 전환 필요 (팀 회의 필요).
 

--- a/src/entities/chat/ui/ChatRoomItem.tsx
+++ b/src/entities/chat/ui/ChatRoomItem.tsx
@@ -45,7 +45,7 @@ export function ChatRoomItem({
 						{/* 안읽은 메세지 카운트 뱃지 */}
 						{unreadCount > 0 && (
 							<View className="rounded-full bg-primary justify-center px-[8px]">
-								<Text className="font-regular text-[12px] leading-[22px] tracking-[-0.41px] text-white">
+								<Text className="font-regular text-[12px] leading-[22px] tracking-[-0.41px] text-content-inverse">
 									{displayCount}
 								</Text>
 							</View>

--- a/src/entities/chat/ui/MessageBubble.tsx
+++ b/src/entities/chat/ui/MessageBubble.tsx
@@ -18,7 +18,7 @@ export function MessageBubble({ text, variant }: MessageBubbleProps) {
 			<Text
 				className={[
 					"font-light text-[14px]",
-					isSent ? "text-white" : "text-content-primary",
+					isSent ? "text-content-inverse" : "text-content-primary",
 				].join(" ")}
 			>
 				{text}

--- a/src/entities/partner/ui/PartnerItem.tsx
+++ b/src/entities/partner/ui/PartnerItem.tsx
@@ -10,7 +10,7 @@ export const PartnerItem = ({ rank, name }: PartnerItemProps) => {
 			<Text className="assu-main font-bold w-7 text-base">{rank}</Text>
 
 			<Text
-				className="text-slate-800 text-base font-medium flex-1"
+				className="text-content-primary text-base font-medium flex-1"
 				numberOfLines={1}
 				ellipsizeMode="tail"
 			>

--- a/src/entities/partnership/ui/AffiliationSummaryCard.tsx
+++ b/src/entities/partnership/ui/AffiliationSummaryCard.tsx
@@ -29,7 +29,7 @@ export const AffiliationSummaryCard = memo(
 					onPress={onPress}
 					className="rounded-lg bg-primary px-5 py-2"
 				>
-					<Text className="text-center text-xs font-semibold text-white">
+					<Text className="text-center text-xs font-semibold text-content-inverse">
 						문의하기
 					</Text>
 				</Pressable>

--- a/src/entities/report/api/createReport.ts
+++ b/src/entities/report/api/createReport.ts
@@ -1,0 +1,47 @@
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
+import type {
+	CreateReportPayload,
+	CreateReportRequestDto,
+	CreateReportResponseDto,
+	ReportReason,
+	ReportTargetType,
+	ReportType,
+} from "../model/types";
+
+const REPORT_TYPE_MAP: Record<
+	ReportTargetType,
+	Record<ReportReason, ReportType>
+> = {
+	REVIEW: {
+		inappropriate: "REVIEW_INAPPROPRIATE_CONTENT",
+		false: "REVIEW_FALSE_INFORMATION",
+		ad: "REVIEW_SPAM",
+	},
+	SUGGESTION: {
+		inappropriate: "SUGGESTION_INAPPROPRIATE_CONTENT",
+		false: "SUGGESTION_FALSE_INFORMATION",
+		ad: "SUGGESTION_SPAM",
+	},
+};
+
+export async function createReport({
+	reportTarget,
+	targetType,
+	targetId,
+	reason,
+}: CreateReportPayload): Promise<CreateReportResponseDto> {
+	const body: CreateReportRequestDto = {
+		targetType,
+		targetId,
+		reportType: REPORT_TYPE_MAP[targetType][reason],
+	};
+	const endpoint = reportTarget === "user" ? "/reports/students" : "/reports";
+	if (__DEV__) console.log("[createReport] 요청:", endpoint, body);
+	const res = await apiInstance.post<BaseResponse<CreateReportResponseDto>>(
+		endpoint,
+		body,
+	);
+	if (__DEV__) console.log("[createReport] 응답:", res.data.result);
+	return res.data.result;
+}

--- a/src/entities/report/index.ts
+++ b/src/entities/report/index.ts
@@ -1,0 +1,10 @@
+export { createReport } from "./api/createReport";
+export type {
+	CreateReportPayload,
+	CreateReportRequestDto,
+	CreateReportResponseDto,
+	ReportReason,
+	ReportSubject,
+	ReportTargetType,
+	ReportType,
+} from "./model/types";

--- a/src/entities/report/model/types.ts
+++ b/src/entities/report/model/types.ts
@@ -1,0 +1,28 @@
+export type ReportTargetType = "REVIEW" | "SUGGESTION";
+export type ReportReason = "inappropriate" | "false" | "ad";
+export type ReportSubject = "user" | "post";
+
+export type CreateReportPayload = {
+	reportTarget: ReportSubject;
+	targetType: ReportTargetType;
+	targetId: number;
+	reason: ReportReason;
+};
+
+export type ReportType =
+	| "REVIEW_INAPPROPRIATE_CONTENT"
+	| "REVIEW_FALSE_INFORMATION"
+	| "REVIEW_SPAM"
+	| "SUGGESTION_INAPPROPRIATE_CONTENT"
+	| "SUGGESTION_FALSE_INFORMATION"
+	| "SUGGESTION_SPAM";
+
+export interface CreateReportRequestDto {
+	targetType: ReportTargetType;
+	targetId: number;
+	reportType: ReportType;
+}
+
+export interface CreateReportResponseDto {
+	reportId: number;
+}

--- a/src/entities/review/api/useReviews.ts
+++ b/src/entities/review/api/useReviews.ts
@@ -1,0 +1,104 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
+import { toReview } from "../lib/adapters";
+import type {
+	CheckReviewResponseDto,
+	PageableParams,
+	PageResponseDto,
+	StandardScoreResponseDto,
+} from "../model/api-types";
+import type { Review } from "../model/types";
+
+export interface ReviewPage {
+	reviews: Review[];
+	totalElements: number;
+	totalPages: number;
+	page: number;
+	size: number;
+	isLast: boolean;
+}
+
+const DEFAULT_PAGEABLE = {
+	page: 0,
+	size: 100,
+} satisfies PageableParams;
+
+function withDefaultPageable(params?: PageableParams): PageableParams {
+	return {
+		...DEFAULT_PAGEABLE,
+		...params,
+	};
+}
+
+async function fetchReviewPage(
+	endpoint: string,
+	params?: PageableParams,
+): Promise<ReviewPage> {
+	const requestParams = withDefaultPageable(params);
+	if (__DEV__) console.log("[fetchReviewPage] 요청:", endpoint, requestParams);
+	const res = await apiInstance.get<
+		BaseResponse<PageResponseDto<CheckReviewResponseDto>>
+	>(endpoint, {
+		params: requestParams,
+	});
+	const page = res.data.result;
+	if (__DEV__)
+		console.log("[fetchReviewPage] 응답:", {
+			totalElements: page.totalElements,
+			numberOfElements: page.numberOfElements,
+		});
+
+	return {
+		reviews: page.content.map(toReview),
+		totalElements: page.totalElements,
+		totalPages: page.totalPages,
+		page: page.number,
+		size: page.size,
+		isLast: page.last,
+	};
+}
+
+async function fetchPartnerReviewAverage(): Promise<number> {
+	if (__DEV__)
+		console.log("[fetchPartnerReviewAverage] 요청:", "/reviews/average");
+	const res =
+		await apiInstance.get<BaseResponse<StandardScoreResponseDto>>(
+			"/reviews/average",
+		);
+	if (__DEV__)
+		console.log("[fetchPartnerReviewAverage] 응답:", res.data.result);
+	return res.data.result.score;
+}
+
+export function useStudentReviews(params?: PageableParams) {
+	return useQuery({
+		queryKey: ["reviews", "student", params],
+		queryFn: () => fetchReviewPage("/reviews/student", params),
+	});
+}
+
+export function usePartnerReviews(params?: PageableParams) {
+	return useQuery({
+		queryKey: ["reviews", "partner", params],
+		queryFn: () => fetchReviewPage("/reviews/partner", params),
+	});
+}
+
+export function useStoreReviews(
+	storeId: number | null,
+	params?: PageableParams,
+) {
+	return useQuery({
+		queryKey: ["reviews", "store", storeId, params],
+		queryFn: () => fetchReviewPage(`/reviews/store/${storeId}`, params),
+		enabled: storeId !== null,
+	});
+}
+
+export function usePartnerReviewAverage() {
+	return useQuery({
+		queryKey: ["reviews", "partner", "average"],
+		queryFn: fetchPartnerReviewAverage,
+	});
+}

--- a/src/entities/review/api/useReviews.ts
+++ b/src/entities/review/api/useReviews.ts
@@ -38,24 +38,27 @@ async function fetchReviewPage(
 	const requestParams = withDefaultPageable(params);
 	if (__DEV__) console.log("[fetchReviewPage] 요청:", endpoint, requestParams);
 	const res = await apiInstance.get<
-		BaseResponse<PageResponseDto<CheckReviewResponseDto>>
+		BaseResponse<PageResponseDto<CheckReviewResponseDto> | null>
 	>(endpoint, {
 		params: requestParams,
 	});
 	const page = res.data.result;
+	const rawContent = page?.content;
+	const content = Array.isArray(rawContent) ? rawContent : [];
+	const reviews = content.map(toReview);
 	if (__DEV__)
 		console.log("[fetchReviewPage] 응답:", {
-			totalElements: page.totalElements,
-			numberOfElements: page.numberOfElements,
+			totalElements: page?.totalElements ?? reviews.length,
+			numberOfElements: page?.numberOfElements ?? reviews.length,
 		});
 
 	return {
-		reviews: page.content.map(toReview),
-		totalElements: page.totalElements,
-		totalPages: page.totalPages,
-		page: page.number,
-		size: page.size,
-		isLast: page.last,
+		reviews,
+		totalElements: page?.totalElements ?? reviews.length,
+		totalPages: page?.totalPages ?? 0,
+		page: page?.number ?? requestParams.page ?? DEFAULT_PAGEABLE.page,
+		size: page?.size ?? requestParams.size ?? DEFAULT_PAGEABLE.size,
+		isLast: page?.last ?? true,
 	};
 }
 

--- a/src/entities/review/index.ts
+++ b/src/entities/review/index.ts
@@ -1,2 +1,8 @@
+export {
+	usePartnerReviewAverage,
+	usePartnerReviews,
+	useStoreReviews,
+	useStudentReviews,
+} from "./api/useReviews";
 export type { Review, ReviewImage } from "./model/types";
 export { ReviewCard } from "./ui/ReviewCard";

--- a/src/entities/review/lib/adapters.ts
+++ b/src/entities/review/lib/adapters.ts
@@ -1,0 +1,14 @@
+import type { CheckReviewResponseDto } from "../model/api-types";
+import type { Review } from "../model/types";
+
+export function toReview(dto: CheckReviewResponseDto): Review {
+	return {
+		id: String(dto.reviewId),
+		department: dto.storeName || dto.affiliation,
+		studentStatus: dto.affiliation,
+		rating: dto.rate,
+		content: dto.content,
+		images: dto.reviewImageUrls?.map((uri) => ({ uri })),
+		createdAt: new Date(dto.createdAt),
+	};
+}

--- a/src/entities/review/model/api-types.ts
+++ b/src/entities/review/model/api-types.ts
@@ -1,0 +1,49 @@
+export interface PageableParams {
+	page?: number;
+	size?: number;
+	sort?: string[];
+}
+
+export interface SortObjectDto {
+	empty: boolean;
+	unsorted: boolean;
+	sorted: boolean;
+}
+
+export interface PageableObjectDto {
+	offset: number;
+	sort: SortObjectDto;
+	paged: boolean;
+	pageSize: number;
+	pageNumber: number;
+	unpaged: boolean;
+}
+
+export interface PageResponseDto<T> {
+	totalPages: number;
+	totalElements: number;
+	size: number;
+	content: T[];
+	number: number;
+	sort: SortObjectDto;
+	first: boolean;
+	last: boolean;
+	pageable: PageableObjectDto;
+	numberOfElements: number;
+	empty: boolean;
+}
+
+export interface CheckReviewResponseDto {
+	reviewId: number;
+	storeId: number;
+	affiliation: string;
+	storeName: string;
+	content: string;
+	rate: number;
+	createdAt: string;
+	reviewImageUrls?: string[];
+}
+
+export interface StandardScoreResponseDto {
+	score: number;
+}

--- a/src/entities/review/model/types.ts
+++ b/src/entities/review/model/types.ts
@@ -1,5 +1,7 @@
-// ReviewImage: require() 로컬 이미지(number) | 'skeleton'(회색 placeholder)
-export type ReviewImage = number | "skeleton";
+import type { ImageSourcePropType } from "react-native";
+
+// ReviewImage: require() 로컬 이미지, 원격 이미지, 'skeleton'(회색 placeholder)
+export type ReviewImage = ImageSourcePropType | "skeleton";
 
 export interface Review {
 	id: string;

--- a/src/features/admin-dashboard/api/useAdminDashboard.ts
+++ b/src/features/admin-dashboard/api/useAdminDashboard.ts
@@ -30,7 +30,7 @@ async function fetchAdminDashboard(): Promise<DashboardData> {
 		apiInstance.get<BaseResponse<NewCountAdminResponseDto>>(
 			"/admin/dashBoard/new",
 		),
-		apiInstance.get<BaseResponse<CountUsageResponseDto>>(
+		apiInstance.get<BaseResponse<CountUsageResponseDto | null>>(
 			"/admin/dashBoard/top",
 		),
 		apiInstance.get<BaseResponse<CountUsageListResponseDto>>(

--- a/src/features/admin-dashboard/api/useAdminDashboard.ts
+++ b/src/features/admin-dashboard/api/useAdminDashboard.ts
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
+import { toAdminDashboardData } from "../lib/adapters";
+import type {
+	CountAdminAuthResponseDto,
+	CountUsageListResponseDto,
+	CountUsagePersonResponseDto,
+	CountUsageResponseDto,
+	NewCountAdminResponseDto,
+} from "../model/api-types";
+import type { DashboardData } from "../model/types";
+
+async function fetchAdminDashboard(): Promise<DashboardData> {
+	if (__DEV__)
+		console.log("[fetchAdminDashboard] 요청:", [
+			"/admin/dashBoard",
+			"/admin/dashBoard/countUser",
+			"/admin/dashBoard/new",
+			"/admin/dashBoard/top",
+			"/admin/dashBoard/usage",
+		]);
+	const [auth, todayUsage, newCount, topUsage, usageList] = await Promise.all([
+		apiInstance.get<BaseResponse<CountAdminAuthResponseDto>>(
+			"/admin/dashBoard",
+		),
+		apiInstance.get<BaseResponse<CountUsagePersonResponseDto>>(
+			"/admin/dashBoard/countUser",
+		),
+		apiInstance.get<BaseResponse<NewCountAdminResponseDto>>(
+			"/admin/dashBoard/new",
+		),
+		apiInstance.get<BaseResponse<CountUsageResponseDto>>(
+			"/admin/dashBoard/top",
+		),
+		apiInstance.get<BaseResponse<CountUsageListResponseDto>>(
+			"/admin/dashBoard/usage",
+		),
+	]);
+	if (__DEV__)
+		console.log("[fetchAdminDashboard] 응답:", {
+			auth: auth.data.result,
+			todayUsage: todayUsage.data.result,
+			newCount: newCount.data.result,
+			topUsage: topUsage.data.result,
+			usageList: usageList.data.result,
+		});
+
+	return toAdminDashboardData({
+		auth: auth.data.result,
+		newCount: newCount.data.result,
+		todayUsage: todayUsage.data.result,
+		topUsage: topUsage.data.result,
+		usageList: usageList.data.result,
+	});
+}
+
+export function useAdminDashboard() {
+	return useQuery({
+		queryKey: ["admin", "dashboard"],
+		queryFn: fetchAdminDashboard,
+	});
+}

--- a/src/features/admin-dashboard/index.ts
+++ b/src/features/admin-dashboard/index.ts
@@ -1,0 +1,7 @@
+export { useAdminDashboard } from "./api/useAdminDashboard";
+export type {
+	DashboardData,
+	DashboardStats,
+	InsightData,
+	MonthlyUsage,
+} from "./model/types";

--- a/src/features/admin-dashboard/lib/adapters.ts
+++ b/src/features/admin-dashboard/lib/adapters.ts
@@ -1,0 +1,43 @@
+import type {
+	CountAdminAuthResponseDto,
+	CountUsageListResponseDto,
+	CountUsagePersonResponseDto,
+	CountUsageResponseDto,
+	NewCountAdminResponseDto,
+} from "../model/api-types";
+import type { DashboardData, MonthlyUsage } from "../model/types";
+
+export function toAdminDashboardData({
+	auth,
+	newCount,
+	todayUsage,
+	topUsage,
+	usageList,
+}: {
+	auth: CountAdminAuthResponseDto;
+	newCount: NewCountAdminResponseDto;
+	todayUsage: CountUsagePersonResponseDto;
+	topUsage: CountUsageResponseDto;
+	usageList: CountUsageListResponseDto;
+}): DashboardData {
+	const monthlyUsage: MonthlyUsage[] = usageList.items
+		.slice(0, 6)
+		.map((item) => ({
+			month: item.storeName,
+			count: item.usageCount,
+		}));
+
+	return {
+		adminName: auth.adminName,
+		stats: {
+			appCertified: auth.studentCount,
+			newJoined: newCount.newStudentCount,
+			affiliateUsers: todayUsage.usagePersonCount,
+		},
+		monthlyUsage,
+		insight: {
+			topStoreName: topUsage.storeName,
+			expectedCount: topUsage.usageCount,
+		},
+	};
+}

--- a/src/features/admin-dashboard/lib/adapters.ts
+++ b/src/features/admin-dashboard/lib/adapters.ts
@@ -17,10 +17,10 @@ export function toAdminDashboardData({
 	auth: CountAdminAuthResponseDto;
 	newCount: NewCountAdminResponseDto;
 	todayUsage: CountUsagePersonResponseDto;
-	topUsage: CountUsageResponseDto;
+	topUsage: CountUsageResponseDto | null;
 	usageList: CountUsageListResponseDto;
 }): DashboardData {
-	const monthlyUsage: MonthlyUsage[] = usageList.items
+	const monthlyUsage: MonthlyUsage[] = (usageList?.items ?? [])
 		.slice(0, 6)
 		.map((item) => ({
 			month: item.storeName,
@@ -36,8 +36,8 @@ export function toAdminDashboardData({
 		},
 		monthlyUsage,
 		insight: {
-			topStoreName: topUsage.storeName,
-			expectedCount: topUsage.usageCount,
+			topStoreName: topUsage?.storeName ?? null,
+			expectedCount: topUsage?.usageCount ?? 0,
 		},
 	};
 }

--- a/src/features/admin-dashboard/model/api-types.ts
+++ b/src/features/admin-dashboard/model/api-types.ts
@@ -1,0 +1,29 @@
+export interface CountAdminAuthResponseDto {
+	studentCount: number;
+	adminId: number;
+	adminName: string;
+}
+
+export interface CountUsagePersonResponseDto {
+	usagePersonCount: number;
+	adminId: number;
+	adminName: string;
+}
+
+export interface NewCountAdminResponseDto {
+	newStudentCount: number;
+	adminId: number;
+	adminName: string;
+}
+
+export interface CountUsageResponseDto {
+	usageCount: number;
+	adminId: number;
+	adminName: string;
+	storeId: number;
+	storeName: string;
+}
+
+export interface CountUsageListResponseDto {
+	items: CountUsageResponseDto[];
+}

--- a/src/features/admin-dashboard/model/types.ts
+++ b/src/features/admin-dashboard/model/types.ts
@@ -1,0 +1,22 @@
+export interface DashboardStats {
+	appCertified: number;
+	newJoined: number;
+	affiliateUsers: number;
+}
+
+export interface MonthlyUsage {
+	month: string;
+	count: number;
+}
+
+export interface InsightData {
+	topStoreName: string | null;
+	expectedCount: number;
+}
+
+export interface DashboardData {
+	adminName: string;
+	stats: DashboardStats;
+	monthlyUsage: MonthlyUsage[];
+	insight: InsightData;
+}

--- a/src/features/admin-suggestion-list/api/useSuggestionList.ts
+++ b/src/features/admin-suggestion-list/api/useSuggestionList.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
+import { toSuggestion } from "../lib/adapters";
+import type { GetSuggestionResponseDto } from "../model/api-types";
+import type { Suggestion } from "../model/types";
+
+async function fetchSuggestionList(): Promise<Suggestion[]> {
+	if (__DEV__) console.log("[fetchSuggestionList] 요청:", "/suggestion/list");
+	const res =
+		await apiInstance.get<BaseResponse<GetSuggestionResponseDto[]>>(
+			"/suggestion/list",
+		);
+	if (__DEV__)
+		console.log("[fetchSuggestionList] 응답:", {
+			count: res.data.result.length,
+			items: res.data.result,
+		});
+	return res.data.result.map(toSuggestion);
+}
+
+export function useSuggestionList() {
+	return useQuery({
+		queryKey: ["suggestion", "list"],
+		queryFn: fetchSuggestionList,
+	});
+}

--- a/src/features/admin-suggestion-list/index.ts
+++ b/src/features/admin-suggestion-list/index.ts
@@ -1,0 +1,2 @@
+export { useSuggestionList } from "./api/useSuggestionList";
+export type { Suggestion } from "./model/types";

--- a/src/features/admin-suggestion-list/lib/adapters.ts
+++ b/src/features/admin-suggestion-list/lib/adapters.ts
@@ -19,7 +19,9 @@ const STATUS_LABELS: Record<string, string> = {
 	GRADUATED: "졸업생",
 };
 
-function toReadableEnum(value: string): string {
+function toReadableEnum(value?: string | null): string {
+	if (!value) return "";
+
 	return value
 		.split("_")
 		.map((word) => word.slice(0, 1) + word.slice(1).toLowerCase())
@@ -32,7 +34,8 @@ export function toSuggestion(dto: GetSuggestionResponseDto): Suggestion {
 		storeName: dto.storeName,
 		department:
 			MAJOR_LABELS[dto.studentMajor] ?? toReadableEnum(dto.studentMajor),
-		studentStatus: STATUS_LABELS[dto.enrollmentStatus] ?? dto.enrollmentStatus,
+		studentStatus:
+			STATUS_LABELS[dto.enrollmentStatus] ?? dto.enrollmentStatus ?? "",
 		content: dto.content,
 		createdAt: new Date(dto.createdAt),
 	};

--- a/src/features/admin-suggestion-list/lib/adapters.ts
+++ b/src/features/admin-suggestion-list/lib/adapters.ts
@@ -1,0 +1,39 @@
+import type { GetSuggestionResponseDto } from "../model/api-types";
+import type { Suggestion } from "../model/types";
+
+const MAJOR_LABELS: Record<string, string> = {
+	GLOBAL_MEDIA: "글로벌미디어학부",
+	COMPUTER_SCIENCE: "컴퓨터학부",
+	BUSINESS_ADMINISTRATION: "경영학부",
+	SOCIAL_WELFARE: "사회복지학부",
+	MEDIA_COMMUNICATION: "언론홍보학과",
+	SOFTWARE: "소프트웨어학부",
+	AI_CONVERGENCE: "AI융합학부",
+	ECONOMICS: "경제학과",
+	LAW: "법학과",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+	ENROLLED: "재학생",
+	LEAVE: "휴학생",
+	GRADUATED: "졸업생",
+};
+
+function toReadableEnum(value: string): string {
+	return value
+		.split("_")
+		.map((word) => word.slice(0, 1) + word.slice(1).toLowerCase())
+		.join(" ");
+}
+
+export function toSuggestion(dto: GetSuggestionResponseDto): Suggestion {
+	return {
+		id: String(dto.suggestionId),
+		storeName: dto.storeName,
+		department:
+			MAJOR_LABELS[dto.studentMajor] ?? toReadableEnum(dto.studentMajor),
+		studentStatus: STATUS_LABELS[dto.enrollmentStatus] ?? dto.enrollmentStatus,
+		content: dto.content,
+		createdAt: new Date(dto.createdAt),
+	};
+}

--- a/src/features/admin-suggestion-list/model/api-types.ts
+++ b/src/features/admin-suggestion-list/model/api-types.ts
@@ -1,0 +1,11 @@
+export type StudentMajor = string;
+export type EnrollmentStatus = "ENROLLED" | "LEAVE" | "GRADUATED";
+
+export interface GetSuggestionResponseDto {
+	suggestionId: number;
+	createdAt: string;
+	storeName: string;
+	content: string;
+	studentMajor: StudentMajor;
+	enrollmentStatus: EnrollmentStatus;
+}

--- a/src/features/admin-suggestion-list/model/types.ts
+++ b/src/features/admin-suggestion-list/model/types.ts
@@ -1,0 +1,8 @@
+export type Suggestion = {
+	id: string;
+	storeName: string;
+	department: string;
+	studentStatus: string;
+	content: string;
+	createdAt: Date;
+};

--- a/src/features/inquiry-form/ui/InquiryForm.tsx
+++ b/src/features/inquiry-form/ui/InquiryForm.tsx
@@ -96,7 +96,7 @@ export function InquiryForm({ userEmail, onSubmitHandler }: InquiryFormProps) {
 					)}
 				/>
 				{errors.title && (
-					<Text className="text-xs text-red-500">{errors.title.message}</Text>
+					<Text className="text-xs text-danger">{errors.title.message}</Text>
 				)}
 			</View>
 
@@ -127,7 +127,7 @@ export function InquiryForm({ userEmail, onSubmitHandler }: InquiryFormProps) {
 					)}
 				/>
 				{errors.content && (
-					<Text className="text-xs text-red-500">{errors.content.message}</Text>
+					<Text className="text-xs text-danger">{errors.content.message}</Text>
 				)}
 			</View>
 
@@ -156,7 +156,7 @@ export function InquiryForm({ userEmail, onSubmitHandler }: InquiryFormProps) {
 					)}
 				/>
 				{errors.email && (
-					<Text className="text-xs text-red-500">{errors.email.message}</Text>
+					<Text className="text-xs text-danger">{errors.email.message}</Text>
 				)}
 			</View>
 

--- a/src/features/map-search/index.ts
+++ b/src/features/map-search/index.ts
@@ -1,1 +1,6 @@
-export { usePopularStores, useSearchStores } from "./model/useMapSearch";
+export type { MapViewport } from "./model/useMapSearch";
+export {
+	useNearbyStores,
+	usePopularStores,
+	useSearchStores,
+} from "./model/useMapSearch";

--- a/src/features/map-search/model/useMapSearch.ts
+++ b/src/features/map-search/model/useMapSearch.ts
@@ -1,119 +1,269 @@
 import { useQuery } from "@tanstack/react-query";
 
-import type { PopularStore, SearchResultStore } from "@/entities/store";
+import type {
+	PopularStore,
+	SearchResultStore,
+	StoreMarker,
+} from "@/entities/store";
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
 
-const MOCK_POPULAR_STORES: PopularStore[] = [
-	{ id: "1", name: "역전할머니맥주" },
-	{ id: "2", name: "취향" },
-	{ id: "3", name: "Bread & co" },
-	{ id: "4", name: "인쌩맥주" },
-	{ id: "5", name: "리얼후라이" },
-	{ id: "6", name: "이자카야 젠" },
-	{ id: "7", name: "상도로 3가" },
-	{ id: "8", name: "인쌩맥주" },
-];
+export interface MapViewport {
+	lng1: number;
+	lat1: number;
+	lng2: number;
+	lat2: number;
+	lng3: number;
+	lat3: number;
+	lng4: number;
+	lat4: number;
+}
 
-const MOCK_SEARCH_STORES: SearchResultStore[] = [
-	{
-		id: "1",
-		name: "역전할머니맥주 숭실대점",
-		tag: "IT대 학생회",
-		benefit: "4인이상 식사시, 음료제공",
-		address: "서울 동작구 상도로 369",
-		isPartner: true,
-		partnershipStartDate: "2025.02.24",
-		partnershipEndDate: "2025.06.15",
-	},
-	{
-		id: "2",
-		name: "취향",
-		tag: "총학생회",
-		benefit: "4인이상 식사시, 음료제공",
-		address: "서울 동작구 사당로 36-1",
-		isPartner: true,
-		partnershipStartDate: "2025.03.01",
-		partnershipEndDate: "2025.08.31",
-	},
-	{
-		id: "3",
-		name: "Bread & co",
-		tag: "공대 학생회",
-		benefit: "음료 10% 할인",
-		address: "서울 동작구 상도로 312",
+interface PlaceSuggestionDto {
+	placeId: string;
+	name: string;
+	category?: string;
+	address?: string;
+	roadAddress?: string;
+	phone?: string;
+	placeUrl?: string;
+	latitude?: number;
+	longitude?: number;
+	distance?: number;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const SOONGSIL_VIEWPORT: MapViewport = {
+	lng1: 126.9472,
+	lat1: 37.5063,
+	lng2: 126.9672,
+	lat2: 37.5063,
+	lng3: 126.9672,
+	lat3: 37.4863,
+	lng4: 126.9472,
+	lat4: 37.4863,
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(record: UnknownRecord, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.length > 0) return value;
+		if (typeof value === "number") return String(value);
+	}
+	return undefined;
+}
+
+function getNumber(record: UnknownRecord, keys: string[]): number | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "number") return value;
+		if (typeof value === "string") {
+			const parsed = Number(value);
+			if (!Number.isNaN(parsed)) return parsed;
+		}
+	}
+	return undefined;
+}
+
+function getBoolean(
+	record: UnknownRecord,
+	keys: string[],
+): boolean | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "boolean") return value;
+	}
+	return undefined;
+}
+
+function pickList(value: unknown): unknown[] {
+	if (Array.isArray(value)) return value;
+	if (!isRecord(value)) return [];
+
+	for (const key of [
+		"items",
+		"content",
+		"stores",
+		"places",
+		"data",
+		"result",
+	]) {
+		const nested = value[key];
+		if (Array.isArray(nested)) return nested;
+	}
+
+	return [];
+}
+
+function toSearchResultStore(value: unknown): SearchResultStore | null {
+	if (!isRecord(value)) return null;
+
+	const id = getString(value, ["id", "storeId", "placeId", "kakaoId"]);
+	const name = getString(value, ["name", "storeName", "placeName"]);
+	if (!id || !name) return null;
+	const hasPartnership =
+		value.partnershipId !== undefined || value.partnership !== undefined;
+
+	return {
+		id,
+		name,
+		imageUri: getString(value, ["imageUri", "imageUrl", "storeImageUrl"]),
+		tag: getString(value, ["tag", "adminName", "affiliation", "category"]),
+		benefit: getString(value, [
+			"benefit",
+			"benefitDescription",
+			"partnershipBenefit",
+			"description",
+		]),
+		address: getString(value, ["address", "roadAddress", "storeAddress"]),
+		isPartner: getBoolean(value, ["isPartner", "partner"]) ?? hasPartnership,
+		partnershipStartDate: getString(value, [
+			"partnershipStartDate",
+			"startDate",
+		]),
+		partnershipEndDate: getString(value, ["partnershipEndDate", "endDate"]),
+	};
+}
+
+function toPlaceSearchResult(dto: PlaceSuggestionDto): SearchResultStore {
+	return {
+		id: dto.placeId,
+		name: dto.name,
+		tag: dto.category,
+		address: dto.roadAddress || dto.address,
 		isPartner: false,
-	},
-	{
-		id: "4",
-		name: "인쌩맥주",
-		tag: "생활관",
-		benefit: "빵 구매 시 아메리카노 제공",
-		address: "서울 동작구 상도로 407",
-		isPartner: true,
-		partnershipStartDate: "2025.01.15",
-		partnershipEndDate: "2025.07.14",
-	},
-	{
-		id: "5",
-		name: "리얼후라이",
-		tag: "총학생회",
-		benefit: "세트 메뉴 10% 할인",
-		address: "서울 동작구 상도로 391",
-		isPartner: false,
-	},
-	{
-		id: "6",
-		name: "이자카야 젠",
-		tag: "IT대 학생회",
-		benefit: "2인 이상 방문 시 음료 1잔 제공",
-		address: "서울 동작구 사당로 34",
-		isPartner: false,
-	},
-	{
-		id: "7",
-		name: "상도로 3가",
-		tag: "생활관",
-		benefit: "식사 후 음료 50% 할인",
-		address: "서울 동작구 상도로 298",
-		isPartner: true,
-		partnershipStartDate: "2025.04.01",
-		partnershipEndDate: "2025.09.30",
-	},
-	{
-		id: "8",
-		name: "역전 테스트",
-		tag: "IT대 학생회",
-		benefit: "테스트용 혜택입니다",
-		address: "서울 동작구 상도로 99",
-		isPartner: false,
-	},
-];
+	};
+}
+
+function toStoreMarker(value: unknown): StoreMarker | null {
+	if (!isRecord(value)) return null;
+
+	const id = getString(value, ["id", "storeId", "placeId", "kakaoId"]);
+	const name = getString(value, ["name", "storeName", "placeName"]);
+	const latitude = getNumber(value, ["latitude", "lat", "y"]);
+	const longitude = getNumber(value, ["longitude", "lng", "lon", "x"]);
+	if (!id || !name || latitude === undefined || longitude === undefined) {
+		return null;
+	}
+
+	return {
+		id,
+		name,
+		address: getString(value, ["address", "roadAddress", "storeAddress"]) ?? "",
+		latitude,
+		longitude,
+		count: getNumber(value, ["count", "usageCount"]),
+	};
+}
+
+function dedupeStores(stores: SearchResultStore[]): SearchResultStore[] {
+	const seen = new Set<string>();
+	return stores.filter((store) => {
+		const key = `${store.id}:${store.name}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
+async function fetchNearbyRaw(viewport: MapViewport): Promise<unknown[]> {
+	if (__DEV__) console.log("[fetchNearbyRaw] 요청:", "/map/nearby", viewport);
+	const res = await apiInstance.get<BaseResponse<unknown>>("/map/nearby", {
+		params: viewport,
+	});
+	const result = pickList(res.data.result);
+	if (__DEV__)
+		console.log("[fetchNearbyRaw] 응답:", {
+			count: result.length,
+			result: res.data.result,
+		});
+	return result;
+}
 
 const fetchPopularStores = async (): Promise<PopularStore[]> => {
-	// TODO: replace with actual API call
-	// return apiClient.get("/stores/popular").then(res => res.data);
-	return new Promise((resolve) => {
-		setTimeout(() => resolve(MOCK_POPULAR_STORES), 300);
-	});
+	const nearby = await fetchNearbyRaw(SOONGSIL_VIEWPORT);
+	const popularStores = nearby
+		.map(toSearchResultStore)
+		.filter((store): store is SearchResultStore => store !== null)
+		.slice(0, 8)
+		.map((store) => ({
+			id: store.id,
+			name: store.name,
+			category: store.tag,
+		}));
+	if (__DEV__)
+		console.log("[fetchPopularStores] 응답:", {
+			count: popularStores.length,
+			items: popularStores,
+		});
+	return popularStores;
 };
 
 const fetchSearchStores = async (
 	query: string,
 ): Promise<SearchResultStore[]> => {
-	// TODO: replace with actual API call
-	// return apiClient.get("/stores/search", { params: { q: query } }).then(res => res.data);
-	return new Promise((resolve) => {
-		setTimeout(() => {
-			const results = MOCK_SEARCH_STORES.filter((store) =>
-				store.name.toLowerCase().includes(query.toLowerCase()),
-			);
-			resolve(results);
-		}, 300);
-	});
+	if (__DEV__)
+		console.log("[fetchSearchStores] 요청:", {
+			search: { endpoint: "/map/search", searchKeyword: query },
+			place: { endpoint: "/map/place", searchKeyword: query, limit: 10 },
+		});
+	const [storeSearchResult, placeSearchResult] = await Promise.allSettled([
+		apiInstance.get<BaseResponse<unknown>>("/map/search", {
+			params: { searchKeyword: query },
+		}),
+		apiInstance.get<BaseResponse<PlaceSuggestionDto[]>>("/map/place", {
+			params: { searchKeyword: query, limit: 10 },
+		}),
+	]);
+
+	const stores =
+		storeSearchResult.status === "fulfilled"
+			? pickList(storeSearchResult.value.data.result)
+					.map(toSearchResultStore)
+					.filter((store): store is SearchResultStore => store !== null)
+			: [];
+	const places =
+		placeSearchResult.status === "fulfilled"
+			? (Array.isArray(placeSearchResult.value.data.result)
+					? placeSearchResult.value.data.result
+					: []
+				).map(toPlaceSearchResult)
+			: [];
+
+	const results = dedupeStores([...stores, ...places]);
+	if (__DEV__)
+		console.log("[fetchSearchStores] 응답:", {
+			storeCount: stores.length,
+			placeCount: places.length,
+			totalCount: results.length,
+			items: results,
+		});
+	return results;
 };
+
+async function fetchNearbyStores(
+	viewport: MapViewport,
+): Promise<StoreMarker[]> {
+	const nearby = await fetchNearbyRaw(viewport);
+	const markers = nearby
+		.map(toStoreMarker)
+		.filter((marker): marker is StoreMarker => marker !== null);
+	if (__DEV__)
+		console.log("[fetchNearbyStores] 응답:", {
+			count: markers.length,
+			items: markers,
+		});
+	return markers;
+}
 
 export function usePopularStores() {
 	return useQuery<PopularStore[]>({
-		queryKey: ["popularStores"],
+		queryKey: ["map", "nearby", "popular"],
 		queryFn: fetchPopularStores,
 		staleTime: 1000 * 60 * 5,
 	});
@@ -121,9 +271,18 @@ export function usePopularStores() {
 
 export function useSearchStores(query: string) {
 	return useQuery<SearchResultStore[]>({
-		queryKey: ["storeSearch", query],
+		queryKey: ["map", "search", query],
 		queryFn: () => fetchSearchStores(query),
 		enabled: query.trim().length > 0,
+		staleTime: 1000 * 60,
+	});
+}
+
+export function useNearbyStores(viewport: MapViewport | null) {
+	return useQuery<StoreMarker[]>({
+		queryKey: ["map", "nearby", viewport],
+		queryFn: () => fetchNearbyStores(viewport as MapViewport),
+		enabled: viewport !== null,
 		staleTime: 1000 * 60,
 	});
 }

--- a/src/features/map-search/model/useMapSearch.ts
+++ b/src/features/map-search/model/useMapSearch.ts
@@ -176,11 +176,12 @@ async function fetchNearbyRaw(viewport: MapViewport): Promise<unknown[]> {
 	const res = await apiInstance.get<BaseResponse<unknown>>("/map/nearby", {
 		params: viewport,
 	});
-	const result = pickList(res.data.result);
+	const responseResult = res.data?.result;
+	const result = pickList(responseResult);
 	if (__DEV__)
 		console.log("[fetchNearbyRaw] 응답:", {
 			count: result.length,
-			result: res.data.result,
+			result: responseResult,
 		});
 	return result;
 }
@@ -216,24 +217,26 @@ const fetchSearchStores = async (
 		apiInstance.get<BaseResponse<unknown>>("/map/search", {
 			params: { searchKeyword: query },
 		}),
-		apiInstance.get<BaseResponse<PlaceSuggestionDto[]>>("/map/place", {
+		apiInstance.get<BaseResponse<PlaceSuggestionDto[] | null>>("/map/place", {
 			params: { searchKeyword: query, limit: 10 },
 		}),
 	]);
 
-	const stores =
+	const storeResult =
 		storeSearchResult.status === "fulfilled"
-			? pickList(storeSearchResult.value.data.result)
-					.map(toSearchResultStore)
-					.filter((store): store is SearchResultStore => store !== null)
-			: [];
-	const places =
+			? storeSearchResult.value.data?.result
+			: undefined;
+	const placeResult =
 		placeSearchResult.status === "fulfilled"
-			? (Array.isArray(placeSearchResult.value.data.result)
-					? placeSearchResult.value.data.result
-					: []
-				).map(toPlaceSearchResult)
-			: [];
+			? placeSearchResult.value.data?.result
+			: undefined;
+
+	const stores = pickList(storeResult)
+		.map(toSearchResultStore)
+		.filter((store): store is SearchResultStore => store !== null);
+	const places = (Array.isArray(placeResult) ? placeResult : []).map(
+		toPlaceSearchResult,
+	);
 
 	const results = dedupeStores([...stores, ...places]);
 	if (__DEV__)

--- a/src/features/partner-weekly-ranking/api/usePartnerRanking.ts
+++ b/src/features/partner-weekly-ranking/api/usePartnerRanking.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BaseResponse } from "@/shared/api";
+import { apiInstance } from "@/shared/api";
+import type { WeeklyRankResponseDto } from "../model/api-types";
+import type { WeeklyRank } from "../model/types";
+
+async function fetchPartnerWeeklyRanking(): Promise<WeeklyRank[]> {
+	if (__DEV__)
+		console.log("[fetchPartnerWeeklyRanking] 요청:", "/store/ranking/weekly");
+	const res = await apiInstance.get<BaseResponse<WeeklyRankResponseDto[]>>(
+		"/store/ranking/weekly",
+	);
+	if (__DEV__)
+		console.log("[fetchPartnerWeeklyRanking] 응답:", res.data.result);
+	return res.data.result.map((item, index) => ({
+		weekLabel: `${index + 1}주차`,
+		rank: item.rank,
+		usageCount: item.usageCount,
+	}));
+}
+
+export function usePartnerWeeklyRanking() {
+	return useQuery({
+		queryKey: ["partner", "store", "ranking", "weekly"],
+		queryFn: fetchPartnerWeeklyRanking,
+	});
+}

--- a/src/features/partner-weekly-ranking/api/usePartnerRanking.ts
+++ b/src/features/partner-weekly-ranking/api/usePartnerRanking.ts
@@ -7,12 +7,12 @@ import type { WeeklyRank } from "../model/types";
 async function fetchPartnerWeeklyRanking(): Promise<WeeklyRank[]> {
 	if (__DEV__)
 		console.log("[fetchPartnerWeeklyRanking] 요청:", "/store/ranking/weekly");
-	const res = await apiInstance.get<BaseResponse<WeeklyRankResponseDto[]>>(
-		"/store/ranking/weekly",
-	);
+	const res = await apiInstance.get<
+		BaseResponse<WeeklyRankResponseDto[] | null>
+	>("/store/ranking/weekly");
 	if (__DEV__)
 		console.log("[fetchPartnerWeeklyRanking] 응답:", res.data.result);
-	return res.data.result.map((item, index) => ({
+	return (res.data.result ?? []).map((item, index) => ({
 		weekLabel: `${index + 1}주차`,
 		rank: item.rank,
 		usageCount: item.usageCount,

--- a/src/features/partner-weekly-ranking/index.ts
+++ b/src/features/partner-weekly-ranking/index.ts
@@ -1,0 +1,2 @@
+export { usePartnerWeeklyRanking } from "./api/usePartnerRanking";
+export type { WeeklyRank } from "./model/types";

--- a/src/features/partner-weekly-ranking/model/api-types.ts
+++ b/src/features/partner-weekly-ranking/model/api-types.ts
@@ -1,0 +1,4 @@
+export interface WeeklyRankResponseDto {
+	rank: number;
+	usageCount: number;
+}

--- a/src/features/partner-weekly-ranking/model/types.ts
+++ b/src/features/partner-weekly-ranking/model/types.ts
@@ -1,0 +1,5 @@
+export interface WeeklyRank {
+	weekLabel: string;
+	rank: number;
+	usageCount: number;
+}

--- a/src/features/partnership-proposal/model/useFocusBorder.ts
+++ b/src/features/partnership-proposal/model/useFocusBorder.ts
@@ -5,7 +5,7 @@ export function useFocusBorder() {
 	const [focusedField, setFocusedField] = useState<string | null>(null);
 	return {
 		borderColor: (field: string) =>
-			focusedField === field ? colorTokens.primary : "#e0e0e0",
+			focusedField === field ? colorTokens.primary : colorTokens.neutralVariant,
 		onFocus: (field: string) => () => setFocusedField(field),
 		onBlur: () => setFocusedField(null),
 	};

--- a/src/features/partnership-proposal/ui/BenefitCard.tsx
+++ b/src/features/partnership-proposal/ui/BenefitCard.tsx
@@ -62,7 +62,7 @@ export function BenefitCard({ index, onRemove }: Props) {
 						/>
 					</Pressable>
 					{showServiceTypeMenu && (
-						<View className="absolute top-[42px] left-0 z-10 bg-white rounded-lg shadow-md border border-[#e0e0e0] overflow-hidden">
+						<View className="absolute top-[42px] left-0 z-10 bg-canvas rounded-lg shadow-md border border-neutral-variant overflow-hidden">
 							{SERVICE_TYPES.map((type) => (
 								<Pressable
 									key={type}

--- a/src/features/partnership-proposal/ui/DateRangeField.tsx
+++ b/src/features/partnership-proposal/ui/DateRangeField.tsx
@@ -76,7 +76,7 @@ export function DateRangeField({
 			</View>
 
 			{isDateOrderInvalid && (
-				<Text className="text-[12px] text-red-500">
+				<Text className="text-[12px] text-danger">
 					종료일은 시작일보다 이후여야 합니다
 				</Text>
 			)}
@@ -93,8 +93,8 @@ export function DateRangeField({
 
 			{Platform.OS === "ios" && (
 				<Modal transparent animationType="slide" visible={!!dateField}>
-					<Pressable className="flex-1 bg-black/40" onPress={dismiss} />
-					<View className="bg-white rounded-t-2xl px-4 pb-6 pt-2">
+					<Pressable className="flex-1 bg-overlay-strong" onPress={dismiss} />
+					<View className="bg-canvas rounded-t-2xl px-4 pb-6 pt-2">
 						<View className="flex-row justify-between items-center py-3">
 							<Pressable onPress={dismiss}>
 								<Text className="text-[16px] text-content-secondary">취소</Text>

--- a/src/features/partnership-proposal/ui/ProposalCompleteView.tsx
+++ b/src/features/partnership-proposal/ui/ProposalCompleteView.tsx
@@ -27,7 +27,7 @@ export function ProposalCompleteView({ contractId }: Props) {
 				</Text>
 
 				<Pressable
-					className="bg-[#f4f4f5] rounded-lg px-[10px] py-[10px] mt-[11px]"
+					className="bg-neutral rounded-lg px-[10px] py-[10px] mt-[11px]"
 					onPress={() =>
 						router.push({
 							pathname: "/(protected)/partnership-contract/[id]",

--- a/src/features/partnership-proposal/ui/UnderlineField.tsx
+++ b/src/features/partnership-proposal/ui/UnderlineField.tsx
@@ -25,7 +25,10 @@ export function UnderlineField({
 				placeholder={placeholder}
 				placeholderTextColor={colorTokens.contentSecondary}
 				className="text-[17px] text-content-primary px-[15px] py-[8px]"
-				style={{ borderBottomWidth: 0.5, borderBottomColor: "#e0e0e0" }}
+				style={{
+					borderBottomWidth: 0.5,
+					borderBottomColor: colorTokens.neutralVariant,
+				}}
 			/>
 		</View>
 	);

--- a/src/features/partnership-proposal/ui/benefit-fields/ServiceBenefitFields.tsx
+++ b/src/features/partnership-proposal/ui/benefit-fields/ServiceBenefitFields.tsx
@@ -95,7 +95,7 @@ export function ServiceBenefitFields({ index }: Props) {
 								onPress={() => setShowItemInput(true)}
 								className="bg-primary rounded-full px-[10px] py-[4px]"
 							>
-								<Text className="text-[11px] text-white">+ 추가</Text>
+								<Text className="text-[11px] text-content-inverse">+ 추가</Text>
 							</Pressable>
 						)}
 					</View>

--- a/src/features/qr-auth/ui/QRScannerButton.tsx
+++ b/src/features/qr-auth/ui/QRScannerButton.tsx
@@ -4,12 +4,12 @@ import { InfoLinkText } from "@/shared/ui/info";
 
 export const QRScannerButton = () => {
 	return (
-		<Pressable className="bg-gray-100 rounded-2xl p-6 flex-row items-center">
+		<Pressable className="bg-neutral rounded-2xl p-6 flex-row items-center">
 			<View>
 				<QrIcon width={40} height={40} className="pl-2" />
 			</View>
 			<View>
-				<Text className="text-lg font-bold text-slate-900">
+				<Text className="text-lg font-bold text-content-primary">
 					제휴 QR 인증하기
 				</Text>
 				<InfoLinkText message="숭실대학교 학생인증이 완료된 사용자" />

--- a/src/features/report-review/model/useReportReview.ts
+++ b/src/features/report-review/model/useReportReview.ts
@@ -1,1 +1,27 @@
-export { useReportSteps as useReportReview } from "@/shared/ui/report";
+import { useCallback } from "react";
+import { createReport, type ReportReason } from "@/entities/report";
+import { useReportSteps } from "@/shared/ui/report";
+
+export function useReportReview() {
+	const handleSubmit = useCallback(
+		async ({
+			entityId,
+			target,
+			reason,
+		}: {
+			entityId: string;
+			target: "user" | "post";
+			reason: string;
+		}) => {
+			await createReport({
+				reportTarget: target,
+				targetType: "REVIEW",
+				targetId: Number(entityId),
+				reason: reason as ReportReason,
+			});
+		},
+		[],
+	);
+
+	return useReportSteps({ onSubmit: handleSubmit });
+}

--- a/src/features/report-suggestion/model/useReportSuggestion.ts
+++ b/src/features/report-suggestion/model/useReportSuggestion.ts
@@ -1,1 +1,27 @@
-export { useReportSteps as useReportSuggestion } from "@/shared/ui/report";
+import { useCallback } from "react";
+import { createReport, type ReportReason } from "@/entities/report";
+import { useReportSteps } from "@/shared/ui/report";
+
+export function useReportSuggestion() {
+	const handleSubmit = useCallback(
+		async ({
+			entityId,
+			target,
+			reason,
+		}: {
+			entityId: string;
+			target: "user" | "post";
+			reason: string;
+		}) => {
+			await createReport({
+				reportTarget: target,
+				targetType: "SUGGESTION",
+				targetId: Number(entityId),
+				reason: reason as ReportReason,
+			});
+		},
+		[],
+	);
+
+	return useReportSteps({ onSubmit: handleSubmit });
+}

--- a/src/features/signup-user-flow/ui/SignupStepContent.tsx
+++ b/src/features/signup-user-flow/ui/SignupStepContent.tsx
@@ -1,10 +1,7 @@
 import { useFormContext } from "react-hook-form";
-import { findAddressOption } from "@/features/signup-user-flow/model/admin";
-import { useSignupFlowUi } from "@/features/signup-user-flow/model/flowUiContext";
-import type {
-	SignupFormState,
-	SignupStep,
-} from "@/features/signup-user-flow/model/types";
+import { findAddressOption } from "../model/admin";
+import { useSignupFlowUi } from "../model/flowUiContext";
+import type { SignupFormState, SignupStep } from "../model/types";
 import { AdminCredentialsStepSection } from "./sections/AdminCredentialsStepSection";
 import { AdminOrganizationInfoStepSection } from "./sections/AdminOrganizationInfoStepSection";
 import { AdminOrganizationTypeStepSection } from "./sections/AdminOrganizationTypeStepSection";

--- a/src/features/signup-user-flow/ui/components/AgreementFooter.tsx
+++ b/src/features/signup-user-flow/ui/components/AgreementFooter.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
 import { View } from "react-native";
-import type { SignupFormState } from "@/features/signup-user-flow/model/types";
+import type { SignupFormState } from "../../model/types";
 import { SignupAgreementSection } from "../SignupAgreementSection";
 
 type AgreementFooterProps = {

--- a/src/features/signup-user-flow/ui/sections/AdminOrganizationInfoStepSection.tsx
+++ b/src/features/signup-user-flow/ui/sections/AdminOrganizationInfoStepSection.tsx
@@ -1,16 +1,16 @@
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { View } from "react-native";
-import { shouldShowAdminOfficeAddressBySelection } from "@/features/signup-user-flow/model/admin";
+import { Select } from "@/shared/ui/select";
+import { shouldShowAdminOfficeAddressBySelection } from "../../model/admin";
 import {
 	ADMIN_COLLEGE_OPTIONS,
 	ADMIN_DEPARTMENT_OPTIONS,
 	ADMIN_ORGANIZATION_TYPE_OPTIONS,
-} from "@/features/signup-user-flow/model/data/adminOptions";
+} from "../../model/data/adminOptions";
 import type {
 	SignupAdminOrganizationType,
 	SignupFormState,
-} from "@/features/signup-user-flow/model/types";
-import { Select } from "@/shared/ui/select";
+} from "../../model/types";
 import { OfficeAddressPicker } from "../components/OfficeAddressPicker";
 import { LabeledInputField } from "../LabeledInputField";
 import { AdminStepLayout } from "../layout/AdminStepLayout";

--- a/src/features/signup-user-flow/ui/sections/AdminOrganizationTypeStepSection.tsx
+++ b/src/features/signup-user-flow/ui/sections/AdminOrganizationTypeStepSection.tsx
@@ -1,10 +1,10 @@
 import { Controller, useFormContext } from "react-hook-form";
-import { ADMIN_ORGANIZATION_TYPE_OPTIONS } from "@/features/signup-user-flow/model/data/adminOptions";
+import { Select } from "@/shared/ui/select";
+import { ADMIN_ORGANIZATION_TYPE_OPTIONS } from "../../model/data/adminOptions";
 import type {
 	SignupAdminOrganizationType,
 	SignupFormState,
-} from "@/features/signup-user-flow/model/types";
-import { Select } from "@/shared/ui/select";
+} from "../../model/types";
 import { AdminStepLayout } from "../layout/AdminStepLayout";
 
 type AdminOrganizationTypeStepSectionProps = {

--- a/src/features/signup-user-flow/ui/sections/AdminSealRegistrationStepSection.tsx
+++ b/src/features/signup-user-flow/ui/sections/AdminSealRegistrationStepSection.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFormContext } from "react-hook-form";
-import type { SignupFormState } from "@/features/signup-user-flow/model/types";
+import type { SignupFormState } from "../../model/types";
 import { AgreementFooter } from "../components/AgreementFooter";
 import { FileUploadButton } from "../components/FileUploadButton";
 import { AdminStepLayout } from "../layout/AdminStepLayout";

--- a/src/features/signup-user-flow/ui/sections/PartnerBusinessRegistrationStepSection.tsx
+++ b/src/features/signup-user-flow/ui/sections/PartnerBusinessRegistrationStepSection.tsx
@@ -1,6 +1,6 @@
 import { Controller, useFormContext } from "react-hook-form";
 import { View } from "react-native";
-import type { SignupFormState } from "@/features/signup-user-flow/model/types";
+import type { SignupFormState } from "../../model/types";
 import { AgreementFooter } from "../components/AgreementFooter";
 import { FileUploadButton } from "../components/FileUploadButton";
 import { SignupStepTitle } from "../SignupStepTitle";

--- a/src/features/signup-user-flow/ui/sections/SchoolStepSection.tsx
+++ b/src/features/signup-user-flow/ui/sections/SchoolStepSection.tsx
@@ -2,8 +2,8 @@ import { Controller, useFormContext } from "react-hook-form";
 import { View } from "react-native";
 import type { SignupSchool } from "@/entities/signup";
 import { SCHOOL_SELECT_OPTIONS } from "@/entities/signup";
-import type { SignupFormState } from "@/features/signup-user-flow/model/types";
 import { Select } from "@/shared/ui/select";
+import type { SignupFormState } from "../../model/types";
 import { SignupStepTitle } from "../SignupStepTitle";
 
 type SchoolStepSectionProps = {

--- a/src/pages/admin/dashboard/model/mockDashboard.ts
+++ b/src/pages/admin/dashboard/model/mockDashboard.ts
@@ -2,6 +2,7 @@
 import type { DashboardData } from "./types";
 
 export const mockDashboardData: DashboardData = {
+	adminName: "숭실대학교 총학생회",
 	stats: {
 		appCertified: 5010,
 		newJoined: 74,
@@ -22,6 +23,7 @@ export const mockDashboardData: DashboardData = {
 };
 
 export const mockEmptyDashboardData: DashboardData = {
+	adminName: "숭실대학교 총학생회",
 	stats: {
 		appCertified: 0,
 		newJoined: 0,

--- a/src/pages/admin/dashboard/model/types.ts
+++ b/src/pages/admin/dashboard/model/types.ts
@@ -1,23 +1,6 @@
-// 관리자 대시보드 타입 정의
-
-export interface DashboardStats {
-	appCertified: number;
-	newJoined: number;
-	affiliateUsers: number;
-}
-
-export interface MonthlyUsage {
-	month: string;
-	count: number;
-}
-
-export interface InsightData {
-	topStoreName: string | null;
-	expectedCount: number;
-}
-
-export interface DashboardData {
-	stats: DashboardStats;
-	monthlyUsage: MonthlyUsage[];
-	insight: InsightData;
-}
+export type {
+	DashboardData,
+	DashboardStats,
+	InsightData,
+	MonthlyUsage,
+} from "@/features/admin-dashboard";

--- a/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
+++ b/src/pages/admin/dashboard/ui/AdminDashboardPage.tsx
@@ -1,14 +1,9 @@
 // 관리자 대시보드 페이지 — 제휴 사용자 현황 전체 레이아웃
 
 import { router } from "expo-router";
-import { useState } from "react";
-import { Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
+import { useAdminDashboard } from "@/features/admin-dashboard";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
-import {
-	mockDashboardData,
-	mockEmptyDashboardData,
-} from "../model/mockDashboard";
-import { ChangeTestButton } from "./ChangeTestButton";
 import { StatCards } from "./StatCards";
 import { UsageSection } from "./UsageSection";
 
@@ -16,11 +11,7 @@ const headingClassName =
 	"text-[22px] font-semibold text-content-primary leading-caption tracking-caption";
 
 export function AdminDashboardPage() {
-	// DEV ONLY
-	const [isEmpty, setIsEmpty] = useState(false);
-	const { stats, monthlyUsage, insight } = isEmpty
-		? mockEmptyDashboardData
-		: mockDashboardData;
+	const { data, isLoading, isError, error } = useAdminDashboard();
 
 	return (
 		<PageLayout
@@ -28,22 +19,27 @@ export function AdminDashboardPage() {
 			contentContainerClassName="px-screen-m gap-[30px] pt-10 pb-10"
 		>
 			<View className="gap-3 px-1">
-				<Text className={headingClassName}>숭실대학교 총학생회</Text>
+				<Text className={headingClassName}>
+					{data?.adminName ?? "숭실대학교 총학생회"}
+				</Text>
 				<Text className={headingClassName}>제휴 사용자가 얼마나 많을까요?</Text>
 			</View>
 
-			<StatCards stats={stats} />
-
-			<UsageSection
-				monthlyUsage={monthlyUsage}
-				insight={insight}
-				devToggle={
-					<ChangeTestButton
-						isEmpty={isEmpty}
-						onToggle={() => setIsEmpty((v) => !v)}
+			{isLoading ? (
+				<View className="items-center py-screen-m">
+					<ActivityIndicator />
+				</View>
+			) : isError ? (
+				<Text className="text-center text-sm text-danger">{String(error)}</Text>
+			) : data ? (
+				<>
+					<StatCards stats={data.stats} />
+					<UsageSection
+						monthlyUsage={data.monthlyUsage}
+						insight={data.insight}
 					/>
-				}
-			/>
+				</>
+			) : null}
 
 			<TouchableOpacity
 				activeOpacity={0.8}

--- a/src/pages/admin/partner-ship-suggestion-box/model/types.ts
+++ b/src/pages/admin/partner-ship-suggestion-box/model/types.ts
@@ -1,10 +1,1 @@
-// 제휴 건의함 도메인 타입 — Suggestion 데이터 구조 정의
-
-export type Suggestion = {
-	id: string;
-	storeName: string;
-	department: string;
-	studentStatus: string;
-	content: string;
-	createdAt: Date;
-};
+export type { Suggestion } from "@/features/admin-suggestion-list";

--- a/src/pages/admin/partner-ship-suggestion-box/ui/AdminSuggestionBoxPage.tsx
+++ b/src/pages/admin/partner-ship-suggestion-box/ui/AdminSuggestionBoxPage.tsx
@@ -1,8 +1,15 @@
 // 관리자 제휴 건의함 페이지 — 건의 건수 + 건의 카드 목록
 
 import { router } from "expo-router";
-import { useCallback, useState } from "react";
-import { FlatList, Pressable, Text, View } from "react-native";
+import { useCallback } from "react";
+import {
+	ActivityIndicator,
+	FlatList,
+	Pressable,
+	Text,
+	View,
+} from "react-native";
+import { useSuggestionList } from "@/features/admin-suggestion-list";
 import {
 	ReportSuggestionDialog,
 	useReportSuggestion,
@@ -11,10 +18,6 @@ import { BackArrowIcon } from "@/shared/assets/icons";
 import { colorTokens } from "@/shared/styles/tokens";
 import { InfoBanner } from "@/shared/ui/info/InfoBanner";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
-import {
-	mockEmptySuggestions,
-	mockSuggestions,
-} from "../model/mockSuggestions";
 import { SuggestionBoxEmptyState } from "./SuggestionBoxEmptyState";
 import { SuggestionCard } from "./SuggestionCard";
 
@@ -27,9 +30,12 @@ const listContentStyle = {
 } as const;
 
 export function AdminSuggestionBoxPage() {
-	// DEV ONLY
-	const [isEmpty, setIsEmpty] = useState(false);
-	const suggestions = isEmpty ? mockEmptySuggestions : mockSuggestions;
+	const {
+		data: suggestions = [],
+		isLoading,
+		isError,
+		error,
+	} = useSuggestionList();
 	const count = suggestions.length;
 
 	const reportState = useReportSuggestion();
@@ -61,14 +67,7 @@ export function AdminSuggestionBoxPage() {
 							제휴건의함
 						</Text>
 					</View>
-					<Pressable
-						onPress={() => setIsEmpty((v) => !v)}
-						className="bg-neutral-variant rounded-sm px-[6px] py-[2px]"
-					>
-						<Text className="text-[10px] font-medium text-content-secondary">
-							{isEmpty ? "돌아가기" : "빈화면"}
-						</Text>
-					</Pressable>
+					<View className="w-6" />
 				</View>
 
 				<View className="px-screen-m gap-screen-m mt-screen-m">
@@ -79,7 +78,17 @@ export function AdminSuggestionBoxPage() {
 					</Text>
 				</View>
 
-				{count === 0 ? (
+				{isLoading ? (
+					<View className="flex-1 items-center justify-center">
+						<ActivityIndicator />
+					</View>
+				) : isError ? (
+					<View className="flex-1 items-center justify-center px-screen-m">
+						<Text className="text-center text-sm text-danger">
+							{String(error)}
+						</Text>
+					</View>
+				) : count === 0 ? (
 					<SuggestionBoxEmptyState />
 				) : (
 					<FlatList

--- a/src/pages/auth/login/ui/LoginPage.tsx
+++ b/src/pages/auth/login/ui/LoginPage.tsx
@@ -9,7 +9,7 @@ export function LoginPage() {
 				className="rounded-lg bg-primary px-4 py-3"
 				onPress={() => router.push("/")}
 			>
-				<Text className="text-sm font-semibold text-white">
+				<Text className="text-sm font-semibold text-content-inverse">
 					허브로 돌아가기
 				</Text>
 			</Pressable>

--- a/src/pages/customer-service/ui/CustomerServicePage.tsx
+++ b/src/pages/customer-service/ui/CustomerServicePage.tsx
@@ -79,9 +79,9 @@ export function CustomerServicePage() {
 							}}
 						>
 							{isPending ? (
-								<ActivityIndicator color="#FFFFFF" />
+								<ActivityIndicator color={colorTokens.contentInverse} />
 							) : (
-								<Text className="text-[20px] font-bold text-white">
+								<Text className="text-[20px] font-bold text-content-inverse">
 									작성하기
 								</Text>
 							)}

--- a/src/pages/customer-service/ui/InquiryItem.tsx
+++ b/src/pages/customer-service/ui/InquiryItem.tsx
@@ -14,7 +14,7 @@ export function InquiryItem({ inquiry }: InquiryItemProps) {
 	return (
 		<Pressable
 			onPress={() => router.push(`/customer-service/${inquiry.id}`)}
-			className="border-b border-gray-200 flex-row items-center justify-between py-[16px] w-full"
+			className="border-b border-neutral-variant flex-row items-center justify-between py-[16px] w-full"
 		>
 			{/* Left: Title */}
 			<View className="flex-1">

--- a/src/pages/customer-service/ui/InquiryList.tsx
+++ b/src/pages/customer-service/ui/InquiryList.tsx
@@ -17,7 +17,7 @@ export function InquiryList() {
 	if (isError) {
 		return (
 			<View className="flex-1 items-center justify-center gap-2">
-				<Text className="text-base font-semibold text-red-500">
+				<Text className="text-base font-semibold text-danger">
 					문의 목록을 불러오는데 실패했습니다.
 				</Text>
 				<Text className="text-sm text-content-secondary">

--- a/src/pages/dev-hub/ui/DevHubPage.tsx
+++ b/src/pages/dev-hub/ui/DevHubPage.tsx
@@ -15,7 +15,7 @@ export function DevHubPage() {
 				className="mb-3 items-center rounded-lg bg-primary py-4"
 				onPress={() => router.push("/(protected)/student/(tabs)/home")}
 			>
-				<Text className="text-sm font-semibold text-white">
+				<Text className="text-sm font-semibold text-content-inverse">
 					학생 홈으로 이동
 				</Text>
 			</Pressable>
@@ -24,7 +24,7 @@ export function DevHubPage() {
 				className="mb-3 items-center rounded-lg bg-primary py-4"
 				onPress={() => router.push("/(protected)/admin/(tabs)/home")}
 			>
-				<Text className="text-sm font-semibold text-white">
+				<Text className="text-sm font-semibold text-content-inverse">
 					관리자 홈으로 이동
 				</Text>
 			</Pressable>
@@ -33,7 +33,7 @@ export function DevHubPage() {
 				className="mb-6 items-center rounded-lg bg-primary py-4"
 				onPress={() => router.push("/(protected)/partner/(tabs)/home")}
 			>
-				<Text className="text-sm font-semibold text-white">
+				<Text className="text-sm font-semibold text-content-inverse">
 					제휴업체 홈으로 이동
 				</Text>
 			</Pressable>

--- a/src/pages/inquiry-detail/ui/InquiryDetailPage.tsx
+++ b/src/pages/inquiry-detail/ui/InquiryDetailPage.tsx
@@ -39,7 +39,7 @@ export function InquiryDetailPage() {
 
 			{isError && (
 				<View className="flex-1 items-center justify-center gap-2">
-					<Text className="text-base font-semibold text-red-500">
+					<Text className="text-base font-semibold text-danger">
 						문의를 불러오는데 실패했습니다.
 					</Text>
 					<Text className="text-sm text-content-secondary">
@@ -61,7 +61,7 @@ export function InquiryDetailPage() {
 					</View>
 
 					{/* 구분선 */}
-					<View className="border-b border-gray-200 mb-6" />
+					<View className="border-b border-neutral-variant mb-6" />
 
 					{/* 본문 */}
 					<Text className="text-[15px] text-content-primary tracking-[0.25px] leading-5 mb-16">
@@ -75,7 +75,7 @@ export function InquiryDetailPage() {
 								Answer
 							</Text>
 						</View>
-						<View className="bg-gray-100 rounded-lg p-4">
+						<View className="bg-neutral rounded-lg p-4">
 							{data.answer ? (
 								<Text className="text-[11px] font-medium text-content-primary tracking-[0.25px] leading-[20px]">
 									{data.answer}

--- a/src/pages/partner/dashboard/ui/PartnerDashboardPage.tsx
+++ b/src/pages/partner/dashboard/ui/PartnerDashboardPage.tsx
@@ -1,10 +1,70 @@
 import { router } from "expo-router";
-import { Pressable, Text, View } from "react-native";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+import { usePartnerWeeklyRanking } from "@/features/partner-weekly-ranking";
 
 export function PartnerDashboardPage() {
+	const {
+		data: weeklyRanks = [],
+		isLoading,
+		isError,
+		error,
+	} = usePartnerWeeklyRanking();
+	const maxUsageCount = Math.max(
+		...weeklyRanks.map((item) => item.usageCount),
+		1,
+	);
+
 	return (
-		<View className="flex-1 items-center justify-center bg-canvas gap-gutter">
-			<Text className="text-content-primary font-medium">업체 대시보드</Text>
+		<View className="flex-1 bg-canvas px-screen-m pt-screen-m gap-screen-m">
+			<View className="gap-2">
+				<Text className="text-xl font-semibold text-content-primary leading-heading">
+					업체 대시보드
+				</Text>
+				<Text className="text-sm text-content-secondary">
+					최근 6주 내 가게 순위와 이용 수를 확인해보세요
+				</Text>
+			</View>
+
+			<View className="bg-neutral rounded-md p-card-p gap-card-p">
+				<Text className="text-md font-medium text-content-primary">
+					주간 순위
+				</Text>
+				{isLoading ? (
+					<View className="items-center py-screen-m">
+						<ActivityIndicator />
+					</View>
+				) : isError ? (
+					<Text className="text-sm text-danger">{String(error)}</Text>
+				) : weeklyRanks.length === 0 ? (
+					<Text className="text-sm text-content-secondary">
+						아직 순위 데이터가 없어요
+					</Text>
+				) : (
+					<View className="gap-gutter">
+						{weeklyRanks.map((item) => (
+							<View key={item.weekLabel} className="gap-gutter">
+								<View className="flex-row items-center justify-between">
+									<Text className="text-sm text-content-primary">
+										{item.weekLabel}
+									</Text>
+									<Text className="text-sm text-content-secondary">
+										{item.rank}위 · {item.usageCount}건
+									</Text>
+								</View>
+								<View className="h-2 rounded-full bg-neutral-variant overflow-hidden">
+									<View
+										className="h-full rounded-full bg-primary"
+										style={{
+											width: `${Math.max((item.usageCount / maxUsageCount) * 100, 5)}%`,
+										}}
+									/>
+								</View>
+							</View>
+						))}
+					</View>
+				)}
+			</View>
+
 			<Pressable
 				onPress={() => router.push("/(protected)/partner/review")}
 				className="bg-primary px-screen-m py-card-p rounded-md items-center"

--- a/src/pages/partner/review/ui/PartnerReviewPage.tsx
+++ b/src/pages/partner/review/ui/PartnerReviewPage.tsx
@@ -2,15 +2,24 @@
 
 import { router } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
-import { FlatList, Pressable, Text, View } from "react-native";
-import { ReviewCard } from "@/entities/review";
+import {
+	ActivityIndicator,
+	FlatList,
+	Pressable,
+	Text,
+	View,
+} from "react-native";
+import {
+	ReviewCard,
+	usePartnerReviewAverage,
+	usePartnerReviews,
+} from "@/entities/review";
 import { ReportReviewDialog, useReportReview } from "@/features/report-review";
 import { BackArrowIcon } from "@/shared/assets/icons";
 import { colorTokens } from "@/shared/styles/tokens";
 import { DarkSelectBottomSheet } from "@/shared/ui/bottom-sheet";
 import { InfoBanner } from "@/shared/ui/info/InfoBanner";
 import { PageLayout } from "@/shared/ui/layout/PageLayout";
-import { mockReviews } from "../model/mockReviews";
 import type { Review } from "../model/types";
 import { ReviewListHeader, type SortType } from "./ReviewListHeader";
 import { ReviewSummary } from "./ReviewSummary";
@@ -20,9 +29,6 @@ const SORT_ITEMS: { label: string; value: SortType }[] = [
 	{ label: "오래된순", value: "oldest" },
 	{ label: "별점순", value: "rating" },
 ];
-
-const averageRating =
-	mockReviews.reduce((sum, r) => sum + r.rating, 0) / mockReviews.length;
 
 const listContentStyle = {
 	gap: 20,
@@ -34,16 +40,24 @@ export function PartnerReviewPage() {
 	const [sort, setSort] = useState<SortType>("latest");
 	const [isSortSheetVisible, setSortSheetVisible] = useState(false);
 	const report = useReportReview();
+	const {
+		data: reviewPage,
+		isLoading: isReviewsLoading,
+		isError: isReviewsError,
+		error: reviewsError,
+	} = usePartnerReviews();
+	const { data: averageRating = 0 } = usePartnerReviewAverage();
+	const reviews = reviewPage?.reviews ?? [];
 
 	const sortedReviews = useMemo(() => {
-		return [...mockReviews].sort((a, b) => {
+		return [...reviews].sort((a, b) => {
 			if (sort === "latest")
 				return b.createdAt.getTime() - a.createdAt.getTime();
 			if (sort === "oldest")
 				return a.createdAt.getTime() - b.createdAt.getTime();
 			return b.rating - a.rating;
 		});
-	}, [sort]);
+	}, [reviews, sort]);
 
 	const renderItem = useCallback(
 		({ item }: { item: Review }) => (
@@ -82,7 +96,7 @@ export function PartnerReviewPage() {
 				<View className="mt-screen-m items-center">
 					<ReviewSummary
 						averageRating={averageRating}
-						totalCount={mockReviews.length}
+						totalCount={reviewPage?.totalElements ?? sortedReviews.length}
 					/>
 				</View>
 
@@ -99,13 +113,25 @@ export function PartnerReviewPage() {
 				</View>
 
 				{/* 카드 스크롤 영역 */}
-				<FlatList<Review>
-					style={{ flex: 1 }}
-					data={sortedReviews}
-					keyExtractor={(item) => item.id}
-					renderItem={renderItem}
-					contentContainerStyle={listContentStyle}
-				/>
+				{isReviewsLoading ? (
+					<View className="flex-1 items-center justify-center">
+						<ActivityIndicator />
+					</View>
+				) : isReviewsError ? (
+					<View className="flex-1 items-center justify-center px-screen-m">
+						<Text className="text-center text-sm text-danger">
+							{String(reviewsError)}
+						</Text>
+					</View>
+				) : (
+					<FlatList<Review>
+						style={{ flex: 1 }}
+						data={sortedReviews}
+						keyExtractor={(item) => item.id}
+						renderItem={renderItem}
+						contentContainerStyle={listContentStyle}
+					/>
+				)}
 			</PageLayout>
 			<ReportReviewDialog state={report} />
 			<DarkSelectBottomSheet

--- a/src/pages/qr-view/ui/QrViewPage.tsx
+++ b/src/pages/qr-view/ui/QrViewPage.tsx
@@ -63,7 +63,7 @@ export function QrViewPage() {
 
 				{/* QR 코드 */}
 				<ViewShot ref={viewShotRef} options={{ format: "png", quality: 1 }}>
-					<View className="p-3 bg-white">
+					<View className="p-3 bg-canvas">
 						<QRCode value={qrValue} size={200} />
 					</View>
 				</ViewShot>

--- a/src/pages/student/home/ui/StudentHomePage.tsx
+++ b/src/pages/student/home/ui/StudentHomePage.tsx
@@ -8,12 +8,12 @@ export function StudentHomePage() {
 	const userStampCount = 4;
 	const userName = "김숭실";
 	return (
-		<ScrollView className="flex-1 bg-white px-5 pt-10">
+		<ScrollView className="flex-1 bg-canvas px-5 pt-10">
 			<Pressable
 				className="rounded-lg bg-primary px-4 py-3"
 				onPress={() => router.push("/")}
 			>
-				<Text className="text-sm font-semibold text-white">
+				<Text className="text-sm font-semibold text-content-inverse">
 					허브로 돌아가기
 				</Text>
 			</Pressable>

--- a/src/pages/student/my-reviews/ui/MyReviewsPage.tsx
+++ b/src/pages/student/my-reviews/ui/MyReviewsPage.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useState } from "react";
-import { FlatList, Pressable, Text, View } from "react-native";
-import { ReviewCard } from "@/entities/review";
+import {
+	ActivityIndicator,
+	FlatList,
+	Pressable,
+	Text,
+	View,
+} from "react-native";
+import { ReviewCard, useStudentReviews } from "@/entities/review";
 import { SortArrowDownIcon } from "@/shared/assets/icons";
 import {
 	type SortOrder,
@@ -11,7 +17,6 @@ import { AppTopBar } from "@/shared/ui/app-top-bar";
 import { DarkSelectBottomSheet } from "@/shared/ui/bottom-sheet";
 import { SmallButton } from "@/shared/ui/buttons/ActionButton";
 import { PageLayout } from "@/shared/ui/layout";
-import { mockReviews } from "../model/mockReviews";
 import type { Review } from "../model/types";
 
 const SORT_ITEMS: { label: string; value: SortOrder }[] = [
@@ -27,11 +32,13 @@ const listContentStyle = {
 
 export function MyReviewsPage() {
 	const [isSortSheetVisible, setSortSheetVisible] = useState(false);
+	const { data, isLoading, isError, error } = useStudentReviews();
 	const {
 		sort,
 		setSort,
 		sortedItems: sortedReviews,
-	} = useSortedByDate(mockReviews);
+	} = useSortedByDate(data?.reviews ?? []);
+	const count = data?.totalElements ?? sortedReviews.length;
 
 	const renderItem = useCallback(
 		({ item }: { item: Review }) => (
@@ -55,9 +62,7 @@ export function MyReviewsPage() {
 				{/* 서브헤더 */}
 				<View className="flex-row items-center justify-between px-screen-m pt-[20px] pb-[16px]">
 					<Text className="text-sm font-medium text-content-primary">
-						작성한 리뷰가{" "}
-						<Text className="text-primary">{sortedReviews.length}</Text>건
-						있어요
+						작성한 리뷰가 <Text className="text-primary">{count}</Text>건 있어요
 					</Text>
 					<Pressable
 						onPress={() => setSortSheetVisible(true)}
@@ -76,7 +81,17 @@ export function MyReviewsPage() {
 				</View>
 
 				{/* 리뷰 목록 또는 빈 상태 */}
-				{sortedReviews.length === 0 ? (
+				{isLoading ? (
+					<View className="flex-1 items-center justify-center">
+						<ActivityIndicator />
+					</View>
+				) : isError ? (
+					<View className="flex-1 items-center justify-center px-screen-m">
+						<Text className="text-center text-sm text-danger">
+							{String(error)}
+						</Text>
+					</View>
+				) : sortedReviews.length === 0 ? (
 					<View className="absolute inset-0 items-center justify-center gap-7">
 						<View className="items-center gap-1.5">
 							<Text className="text-base font-medium text-content-primary">

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -2,3 +2,4 @@ import "./interceptors";
 
 export type { ApiError, ApiResponse } from "@/shared/types/api";
 export { apiInstance } from "./instance";
+export type { BaseResponse } from "./types";

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,6 @@
+export interface BaseResponse<T> {
+	isSuccess: boolean;
+	code: string;
+	message: string;
+	result: T;
+}

--- a/src/shared/styles/global.styles.css
+++ b/src/shared/styles/global.styles.css
@@ -42,6 +42,12 @@
 
 	/* Background Colors - Primitive 참조 */
 	--color-canvas: var(--white);
+	--color-overlay: rgba(0, 0, 0, 0.3);
+	--color-overlay-strong: rgba(0, 0, 0, 0.4);
+	--color-handle-on-dark: rgba(235, 235, 245, 0.3);
+	--color-overlay: rgba(0, 0, 0, 0.3);
+	--color-overlay-strong: rgba(0, 0, 0, 0.4);
+	--color-handle-on-dark: rgba(235, 235, 245, 0.3);
 
 	/* State Colors - Primitive 참조 */
 	--color-danger: var(--red-500);
@@ -51,6 +57,8 @@
 	--color-content-secondary: var(--gray-500);
 	--color-content-tertiary: var(--gray-400);
 	--color-content-inverse: var(--blue-50);
+	--color-content-primary-alpha-45: rgba(4, 4, 4, 0.45);
+	--color-content-primary-alpha-45: rgba(4, 4, 4, 0.45);
 
 	/* Font Sizes */
 	--font-size-sm: 13px;
@@ -134,6 +142,12 @@
 
 	/* Background Colors - Primitive 참조 */
 	--color-canvas: var(--white);
+	--color-overlay: rgba(0, 0, 0, 0.3);
+	--color-overlay-strong: rgba(0, 0, 0, 0.4);
+	--color-handle-on-dark: rgba(235, 235, 245, 0.3);
+	--color-overlay: rgba(0, 0, 0, 0.3);
+	--color-overlay-strong: rgba(0, 0, 0, 0.4);
+	--color-handle-on-dark: rgba(235, 235, 245, 0.3);
 
 	/* State Colors - Primitive 참조 */
 	--color-danger: var(--red-500);
@@ -143,6 +157,8 @@
 	--color-content-secondary: var(--gray-500);
 	--color-content-tertiary: var(--gray-400);
 	--color-content-inverse: var(--blue-50);
+	--color-content-primary-alpha-45: rgba(4, 4, 4, 0.45);
+	--color-content-primary-alpha-45: rgba(4, 4, 4, 0.45);
 
 	/* Font Sizes */
 	--font-size-sm: 13px;

--- a/src/shared/styles/tokens.ts
+++ b/src/shared/styles/tokens.ts
@@ -20,6 +20,13 @@ export const colorTokens = {
 	/** global.styles.css: --color-neutral-variant (gray-300) */
 	neutralVariant: "#DBDDE1",
 
+	/** Modal and bottom-sheet scrim overlay */
+	overlay: "rgba(0, 0, 0, 0.3)",
+	/** Stronger scrim overlay for native picker modals */
+	overlayStrong: "rgba(0, 0, 0, 0.4)",
+	/** Drag handle color on dark sheets */
+	handleOnDark: "rgba(235, 235, 245, 0.3)",
+
 	/** global.styles.css: --color-canvas (white) */
 	canvas: "#FEFFFE",
 
@@ -32,6 +39,8 @@ export const colorTokens = {
 	contentSecondary: "#8E9398",
 	/** contentSecondary at opacity 0.3 — RN은 hex + opacity 조합 불가하므로 별도 정의 */
 	contentSecondaryAlpha30: "rgba(142, 147, 152, 0.3)",
+	/** contentPrimary at opacity 0.45 for placeholders */
+	contentPrimaryAlpha45: "rgba(4, 4, 4, 0.45)",
 	/** global.styles.css: --color-content-tertiary (gray-400) */
 	contentTertiary: "#B4B4B4",
 	/** global.styles.css: --color-content-inverse (blue-50) */

--- a/src/shared/ui/bottom-sheet/BottomActionSheet.tsx
+++ b/src/shared/ui/bottom-sheet/BottomActionSheet.tsx
@@ -56,7 +56,7 @@ export function BottomActionSheet({
 			statusBarTranslucent={Platform.OS === "android"}
 			onRequestClose={onClose}
 		>
-			<View className="flex-1 justify-end bg-[rgba(0,0,0,0.3)]">
+			<View className="flex-1 justify-end bg-overlay">
 				<Pressable className="flex-1" onPress={onClose} />
 				<Animated.View
 					className="rounded-t-[20px] bg-canvas px-screen-m pt-[15px]"

--- a/src/shared/ui/bottom-sheet/DarkSelectBottomSheet.tsx
+++ b/src/shared/ui/bottom-sheet/DarkSelectBottomSheet.tsx
@@ -97,7 +97,7 @@ export function DarkSelectBottomSheet<T extends string = string>({
 			statusBarTranslucent={Platform.OS === "android"}
 			onRequestClose={animateClose}
 		>
-			<View className="flex-1 justify-end bg-[rgba(0,0,0,0.3)]">
+			<View className="flex-1 justify-end bg-overlay">
 				<Pressable className="flex-1" onPress={animateClose} />
 				<Animated.View
 					{...panResponder.panHandlers}
@@ -115,7 +115,7 @@ export function DarkSelectBottomSheet<T extends string = string>({
 								width: 36,
 								height: 5,
 								borderRadius: 100,
-								backgroundColor: "rgba(235, 235, 245, 0.3)",
+								backgroundColor: colorTokens.handleOnDark,
 							}}
 						/>
 					</View>

--- a/src/shared/ui/comment/CommentImages.tsx
+++ b/src/shared/ui/comment/CommentImages.tsx
@@ -15,7 +15,7 @@ export function CommentImages({ images }: CommentImagesProps) {
 				<Image
 					key={imageUri}
 					source={{ uri: imageUri }}
-					className="w-[95px] h-[95px] rounded-md bg-gray-400"
+					className="w-[95px] h-[95px] rounded-md bg-content-tertiary"
 				/>
 			))}
 		</View>

--- a/src/shared/ui/dialog/Dialog.tsx
+++ b/src/shared/ui/dialog/Dialog.tsx
@@ -24,7 +24,7 @@ export function Dialog({ visible, onDismiss, children }: DialogProps) {
 		>
 			<View
 				className="flex-1 justify-center"
-				style={{ backgroundColor: "rgba(0, 0, 0, 0.3)" }}
+				style={{ backgroundColor: colorTokens.overlay }}
 			>
 				<View
 					className="bg-canvas rounded-lg p-6"

--- a/src/shared/ui/dialog/DialogConfirmButton.tsx
+++ b/src/shared/ui/dialog/DialogConfirmButton.tsx
@@ -18,7 +18,7 @@ export function DialogConfirmButton({
 				disabled ? "opacity-disabled" : ""
 			}`}
 		>
-			<Text className="text-white font-semibold text-sm leading-5">
+			<Text className="text-content-inverse font-semibold text-sm leading-5">
 				{children}
 			</Text>
 		</Pressable>

--- a/src/shared/ui/input/LoginUnderlineInput.tsx
+++ b/src/shared/ui/input/LoginUnderlineInput.tsx
@@ -1,4 +1,5 @@
 import { Text, TextInput, View } from "react-native";
+import { colorTokens } from "@/shared/styles/tokens";
 
 type LoginUnderlineInputProps = {
 	label: string;
@@ -25,7 +26,7 @@ export function LoginUnderlineInput({
 				value={value}
 				onChangeText={onChangeText}
 				placeholder={placeholder}
-				placeholderTextColor="rgba(4, 4, 4, 0.45)"
+				placeholderTextColor={colorTokens.contentPrimaryAlpha45}
 				secureTextEntry={secureTextEntry}
 				autoCapitalize="none"
 				autoCorrect={false}

--- a/src/shared/ui/kakao-map/KakaoMap.tsx
+++ b/src/shared/ui/kakao-map/KakaoMap.tsx
@@ -22,16 +22,27 @@ type KakaoMapProps = {
 	initialCenter?: { lat: number; lng: number };
 	myLocation?: { lat: number; lng: number } | null;
 	heading?: number | null;
+	markers?: KakaoMapMarker[];
 };
 
 export type KakaoMapHandle = {
 	panTo: (lat: number, lng: number) => void;
 };
 
+export type KakaoMapMarker = {
+	id: string;
+	name: string;
+	latitude: number;
+	longitude: number;
+};
+
 const SOONGSIL = { lat: 37.4963, lng: 126.9572 };
 
 export const KakaoMap = forwardRef<KakaoMapHandle, KakaoMapProps>(
-	function KakaoMap({ initialCenter = SOONGSIL, myLocation, heading }, ref) {
+	function KakaoMap(
+		{ initialCenter = SOONGSIL, myLocation, heading, markers = [] },
+		ref,
+	) {
 		const appKey = process.env.EXPO_PUBLIC_KAKAO_JS_KEY ?? "";
 		const webViewRef = useRef<WebView>(null);
 		const [isMapReady, setIsMapReady] = useState(false);
@@ -69,6 +80,17 @@ export const KakaoMap = forwardRef<KakaoMapHandle, KakaoMapProps>(
 				`window.updateHeading(${heading ?? "null"}); true;`,
 			);
 		}, [heading, isMapReady]);
+
+		useEffect(() => {
+			if (!isMapReady) return;
+			const serializedMarkers = JSON.stringify(markers).replace(
+				/</g,
+				"\\u003c",
+			);
+			webViewRef.current?.injectJavaScript(
+				`window.updateStoreMarkers(${serializedMarkers}); true;`,
+			);
+		}, [isMapReady, markers]);
 
 		const handleMessage = (event: WebViewMessageEvent) => {
 			try {
@@ -118,6 +140,7 @@ function buildMapHtml(
   <script>
     var map;
     var myLocationOverlay = null;
+    var storeMarkers = [];
 
     function createMyLocationOverlay(position) {
       var content =
@@ -150,6 +173,22 @@ function buildMapHtml(
       var cone = document.getElementById('loc-cone');
       if (!cone || heading === null || heading === undefined) return;
       cone.style.transform = 'rotate(' + heading + 'deg)';
+    };
+
+    window.updateStoreMarkers = function(markers) {
+      storeMarkers.forEach(function(marker) { marker.setMap(null); });
+      storeMarkers = [];
+      if (!Array.isArray(markers)) return;
+
+      markers.forEach(function(markerData) {
+        if (typeof markerData.latitude !== 'number' || typeof markerData.longitude !== 'number') return;
+        var marker = new kakao.maps.Marker({
+          position: new kakao.maps.LatLng(markerData.latitude, markerData.longitude),
+          title: markerData.name || ''
+        });
+        marker.setMap(map);
+        storeMarkers.push(marker);
+      });
     };
 
     function initMap() {

--- a/src/shared/ui/kakao-map/KakaoMap.tsx
+++ b/src/shared/ui/kakao-map/KakaoMap.tsx
@@ -45,6 +45,7 @@ export const KakaoMap = forwardRef<KakaoMapHandle, KakaoMapProps>(
 	) {
 		const appKey = process.env.EXPO_PUBLIC_KAKAO_JS_KEY ?? "";
 		const webViewRef = useRef<WebView>(null);
+		const prevMarkersRef = useRef<string>("");
 		const [isMapReady, setIsMapReady] = useState(false);
 
 		useImperativeHandle(ref, () => ({
@@ -87,6 +88,9 @@ export const KakaoMap = forwardRef<KakaoMapHandle, KakaoMapProps>(
 				/</g,
 				"\\u003c",
 			);
+			if (prevMarkersRef.current === serializedMarkers) return;
+			prevMarkersRef.current = serializedMarkers;
+
 			webViewRef.current?.injectJavaScript(
 				`window.updateStoreMarkers(${serializedMarkers}); true;`,
 			);

--- a/src/shared/ui/profile/ProfileAvatar.tsx
+++ b/src/shared/ui/profile/ProfileAvatar.tsx
@@ -15,7 +15,7 @@ export function ProfileAvatar({ source, size = 48 }: ProfileAvatarProps) {
 
 	return (
 		<View
-			className="items-center justify-center overflow-hidden rounded-full border-[0.5px] border-black"
+			className="items-center justify-center overflow-hidden rounded-full border-[0.5px] border-content-primary"
 			style={{ width: size, height: size }}
 		>
 			<Image

--- a/src/shared/ui/report/ReportModal.tsx
+++ b/src/shared/ui/report/ReportModal.tsx
@@ -29,6 +29,8 @@ export function ReportModal({ state, config }: ReportModalProps) {
 		close,
 		goToReason,
 		goToDone,
+		isSubmitting,
+		errorMessage,
 	} = state;
 
 	return (
@@ -70,11 +72,19 @@ export function ReportModal({ state, config }: ReportModalProps) {
 							</Dialog.RadioItem>
 						))}
 					</Dialog.RadioGroup>
+					{errorMessage && (
+						<Text className="font-regular text-sm text-danger">
+							{errorMessage}
+						</Text>
+					)}
 				</Dialog.Content>
 				<Dialog.Actions>
 					<Dialog.CancelButton onPress={close}>취소</Dialog.CancelButton>
-					<Dialog.ConfirmButton onPress={goToDone} disabled={!reason}>
-						신고하기
+					<Dialog.ConfirmButton
+						onPress={goToDone}
+						disabled={!reason || isSubmitting}
+					>
+						{isSubmitting ? "신고 중" : "신고하기"}
 					</Dialog.ConfirmButton>
 				</Dialog.Actions>
 			</Dialog>

--- a/src/shared/ui/report/useReportSteps.ts
+++ b/src/shared/ui/report/useReportSteps.ts
@@ -1,28 +1,46 @@
 import { useCallback, useState } from "react";
 import type { ReportStep, ReportTarget } from "./types";
 
+interface ReportSubmitParams {
+	entityId: string;
+	target: NonNullable<ReportTarget>;
+	reason: string;
+}
+
+interface UseReportStepsOptions {
+	onSubmit?: (params: ReportSubmitParams) => Promise<void> | void;
+}
+
 interface UseReportStepsReturn {
 	step: ReportStep;
 	entityId: string | null;
 	target: ReportTarget;
 	reason: string | null;
+	isSubmitting: boolean;
+	errorMessage: string | null;
 	setTarget: (value: ReportTarget) => void;
 	setReason: (value: string | null) => void;
 	open: (id: string) => void;
 	close: () => void;
 	goToReason: () => void;
-	goToDone: () => void;
+	goToDone: () => Promise<void>;
 }
 
-export function useReportSteps(): UseReportStepsReturn {
+export function useReportSteps(
+	options: UseReportStepsOptions = {},
+): UseReportStepsReturn {
 	const [step, setStep] = useState<ReportStep>(null);
 	const [entityId, setEntityId] = useState<string | null>(null);
 	const [target, setTarget] = useState<ReportTarget>(null);
 	const [reason, setReason] = useState<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
 	const resetAll = useCallback(() => {
 		setTarget(null);
 		setReason(null);
+		setErrorMessage(null);
+		setIsSubmitting(false);
 	}, []);
 
 	const open = useCallback(
@@ -42,18 +60,32 @@ export function useReportSteps(): UseReportStepsReturn {
 
 	const goToReason = useCallback(() => {
 		setReason(null);
+		setErrorMessage(null);
 		setStep("select-reason");
 	}, []);
 
-	const goToDone = useCallback(() => {
-		setStep("done");
-	}, []);
+	const goToDone = useCallback(async () => {
+		if (!entityId || !target || !reason || isSubmitting) return;
+
+		try {
+			setIsSubmitting(true);
+			setErrorMessage(null);
+			await options.onSubmit?.({ entityId, target, reason });
+			setStep("done");
+		} catch {
+			setErrorMessage("신고 처리 중 문제가 발생했어요. 다시 시도해주세요.");
+		} finally {
+			setIsSubmitting(false);
+		}
+	}, [entityId, isSubmitting, options, reason, target]);
 
 	return {
 		step,
 		entityId,
 		target,
 		reason,
+		isSubmitting,
+		errorMessage,
 		setTarget,
 		setReason,
 		open,

--- a/src/shared/ui/summary-card/SummaryCard.tsx
+++ b/src/shared/ui/summary-card/SummaryCard.tsx
@@ -75,7 +75,9 @@ export const SummaryCard = memo(
 						>
 							<Text
 								className={`text-center font-semibold ${
-									isAffiliated ? "text-sm text-white" : "text-xs text-primary"
+									isAffiliated
+										? "text-sm text-content-inverse"
+										: "text-xs text-primary"
 								}`}
 							>
 								{actionLabel}

--- a/src/widgets/map/ui/AdminStoreCard.tsx
+++ b/src/widgets/map/ui/AdminStoreCard.tsx
@@ -55,7 +55,7 @@ export function AdminStoreCard({ store, onActionPress }: AdminStoreCardProps) {
 					className={`rounded-lg px-[10px] py-[5px] ${isPartner ? "bg-primary" : "bg-primary-tint"}`}
 				>
 					<Text
-						className={`text-center font-regular text-[11px] leading-caption tracking-caption ${isPartner ? "text-white" : "text-primary"}`}
+						className={`text-center font-regular text-[11px] leading-caption tracking-caption ${isPartner ? "text-content-inverse" : "text-primary"}`}
 					>
 						{isPartner ? "제휴 계약서 보기" : "문의하기"}
 					</Text>

--- a/src/widgets/map/ui/MapView.tsx
+++ b/src/widgets/map/ui/MapView.tsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { View } from "react-native";
 
+import { type MapViewport, useNearbyStores } from "@/features/map-search";
 import { KakaoMap, type KakaoMapHandle } from "@/shared/ui/kakao-map";
 import { useUserLocation } from "@/widgets/map/model/useUserLocation";
 
@@ -9,6 +10,8 @@ import { MapLocateButton } from "./MapLocateButton";
 export function MapView() {
 	const kakaoRef = useRef<KakaoMapHandle>(null);
 	const { center, myLocation, heading } = useUserLocation();
+	const viewport = center ? toViewport(center) : null;
+	const { data: nearbyStores = [] } = useNearbyStores(viewport);
 
 	const handleFocusToMyLocation = () => {
 		if (!myLocation) return;
@@ -23,6 +26,7 @@ export function MapView() {
 					initialCenter={center}
 					myLocation={myLocation}
 					heading={heading}
+					markers={nearbyStores}
 				/>
 			) : null}
 			<MapLocateButton
@@ -31,4 +35,20 @@ export function MapView() {
 			/>
 		</View>
 	);
+}
+
+function toViewport(center: { lat: number; lng: number }): MapViewport {
+	const latDelta = 0.01;
+	const lngDelta = 0.01;
+
+	return {
+		lng1: center.lng - lngDelta,
+		lat1: center.lat + latDelta,
+		lng2: center.lng + lngDelta,
+		lat2: center.lat + latDelta,
+		lng3: center.lng + lngDelta,
+		lat3: center.lat - latDelta,
+		lng4: center.lng - lngDelta,
+		lat4: center.lat - latDelta,
+	};
 }

--- a/src/widgets/map/ui/MapView.tsx
+++ b/src/widgets/map/ui/MapView.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 
 import { type MapViewport, useNearbyStores } from "@/features/map-search";
 import { KakaoMap, type KakaoMapHandle } from "@/shared/ui/kakao-map";
-import { useUserLocation } from "@/widgets/map/model/useUserLocation";
+import { useUserLocation } from "../model/useUserLocation";
 
 import { MapLocateButton } from "./MapLocateButton";
 

--- a/src/widgets/partner-ranking/ui/PartnerRankingList.tsx
+++ b/src/widgets/partner-ranking/ui/PartnerRankingList.tsx
@@ -17,9 +17,11 @@ export const PartnerRankingList = () => {
 	const right = MOCK_PARTNERS.filter((_, i) => i % 2 === 1);
 
 	return (
-		<View className="bg-white p-4 rounded-2xl mb-6">
+		<View className="bg-canvas p-4 rounded-2xl mb-6">
 			<Text className="text-lg font-bold mb-1">🔥 Today 제휴 인기 매장</Text>
-			<Text className="text-xs text-gray-400 mb-3">오늘 12:00 기준</Text>
+			<Text className="text-xs text-content-tertiary mb-3">
+				오늘 12:00 기준
+			</Text>
 
 			<View className="flex-row">
 				<View className="flex-1">
@@ -32,7 +34,7 @@ export const PartnerRankingList = () => {
 					))}
 				</View>
 
-				<View className="w-px border-l border-black mx-2" />
+				<View className="w-px border-l border-content-primary mx-2" />
 
 				<View className="flex-1">
 					{right.map((item, i) => (

--- a/src/widgets/stamp-board/ui/StampBoard.tsx
+++ b/src/widgets/stamp-board/ui/StampBoard.tsx
@@ -14,18 +14,18 @@ export const StampBoard = ({ currentCount = 0 }) => {
 	return (
 		<View>
 			<View className="flex-row justify-between items-end pt-5">
-				<Text className="text-gray-900 text-lg font-bold">
+				<Text className="text-content-primary text-lg font-bold">
 					나의 스탬프 적립 현황
 				</Text>
 
 				<TouchableOpacity>
-					<Text className="text-gray-400 text-xs mb-1">
+					<Text className="text-content-tertiary text-xs mb-1">
 						적립 내역 더보기 {">"}
 					</Text>
 				</TouchableOpacity>
 			</View>
 
-			<View className="bg-gray-100 border-gray-600 p-6 rounded-[24px] mt-4 ">
+			<View className="bg-neutral border-neutral-variant p-6 rounded-[24px] mt-4 ">
 				<View className="flex-row flex-wrap justify-between px-1 pt-2">
 					{stamps.map((stamp) => (
 						<View key={stamp.id} style={{ width: "18%", aspectRatio: 1 }}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,9 @@ module.exports = {
 
 				// 배경 색상
 				canvas: "var(--color-canvas)",
+				overlay: "var(--color-overlay)",
+				"overlay-strong": "var(--color-overlay-strong)",
+				"handle-on-dark": "var(--color-handle-on-dark)",
 
 				// 상태별 색상
 				danger: "var(--color-danger)",
@@ -27,6 +30,7 @@ module.exports = {
 				"content-secondary": "var(--color-content-secondary)",
 				"content-tertiary": "var(--color-content-tertiary)",
 				"content-inverse": "var(--color-content-inverse)",
+				"content-primary-alpha-45": "var(--color-content-primary-alpha-45)",
 			},
 			// 폰트 크기
 			fontSize: {


### PR DESCRIPTION
## 📝 요약
  - 담당 페이지의 미연동 API를 Swagger 명세 기준으로 연결했습니다.

  ## 작업 내용
  - 신고, 리뷰, 관리자 대시보드/건의함, 제휴업체 순위/리뷰, 맵 검색/주변 가게 API를 연동했습니다.
  - 로딩/에러/빈 상태 처리와 개발 환경용 요청/응답 로그를 추가했습니다.

  ## 🔗 관련 이슈
  - Closes #119

  ## 체크리스트
  - [x] 코딩 컨벤션(Biome/Lint)을 준수하였습니다.
  - [x] 모든 타입 에러를 해결하였습니다. (Typecheck)
  - [x] 변경 사항에 대한 테스트를 마쳤습니다.
  - [ ] 불필요한 로그(console.log)를 제거하였습니다.

  ## 💬 리뷰어에게
  - 현재 `EXPO_PUBLIC_API_BASE_URL`이 비어 있고 `assu.shop` Swagger 접속이 timeout되어 실제 서버 응답 검증은 정확히 하지 못했습니다.
  - API 확인을 위해 `__DEV__` 조건부 요청/응답 로그를 남겨두었습니다.